### PR TITLE
[chore] docker-compose-local.yml 파일 수정

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -37,16 +37,18 @@ services:
       context: .
       dockerfile: be/Dockerfile
     container_name: eryuk-server
-    working_dir: /app
+    working_dir: /app/be
     env_file:
       - ./be/.env.development
     environment:
       CHOKIDAR_USEPOLLING: "true"
       WATCHPACK_POLLING: "true"
+    command: pnpm dev
     ports:
       - "4000:4000"
     volumes:
       - ./be:/app/be:cached   # 소스만 부분 바인드
+      - /app/be/node_modules  # 컨테이너 내 설치본 유지 (호스트 node_modules 가림 방지)
     depends_on:
       db:
         condition: service_started


### PR DESCRIPTION
## 📝 작업 내용
> server 컨테이너에서 nestjs 모듈 못찾는 문제 해결

- [ ] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [x] 도커 수정

**구체적인 내용**

- be를 바인드 마운트하면서 컨테이너 안에 설치된 node_modules가 가려짐
- server 컨테이너가 워크스페이스 루트 /app 기준으로 실행하면서 실제 의존성이 있는 /app/be/node_modules를 제대로 잡지 못함
- server를 be 워크스페이스 경로에서 직접 실행하도록 함
- server 볼륨에 익명 볼륨을 추가하여 컨테이너 내 node_modules 유지

