### PR TITLE
feat: 레디스 룸 초기화

### DIFF
--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -115,6 +115,14 @@ export const LOG = {
       message: `권한 검증: userId=${userId}, roomId=${roomId}`,
       level: 'debug',
     }),
+    INITIALIZED: {
+      message: `RoomService가 Redis 클라이언트와 함께 초기화되었습니다.`,
+      level: 'log',
+    },
+    ERROR_INITIALIZING_GLOBAL_ROOM: (error: string): LogMessage => ({
+      message: `글로벌 방 초기화 중 오류 발생: ${error}`,
+      level: 'error',
+    }),
   },
 } as const;
 


### PR DESCRIPTION
- 서버 킬때 레디스 룸 1개 생성(글로벌 채팅용)

## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

- chat.gateway.ts 의 onModuleInit 삭제하고 room.service.ts 에 redisClient 주입
  - 이유: 굳이 게이트웨이에서 레디스를 룸으로 주입할 필요가 없다고 생각함
  
- room.service.ts 에 초기화 로직 추가(initializeGlobalRoom 메서드)
  - 서버 실행시 방이 존재하지 않으면 방 생성

- chat.gateway.ts 의 handleConnection메서드 수정
  - 인증된 사용자가 소켓에 연결된 경우, 레디스 룸에 join하는 로직 추가

- log-messages.ts 에 로그용 이넘 추가
  - 성공적인 초기화를 의미하는 INITIALIZED 추가
  - 초기화 실패를 의미하는 ERROR_INITIALIZING_GLOBAL_ROOM 추가
