### PR TITLE
[Feat] 로컬 방 목록 조회 및 검색 조회 구현

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -34,3 +34,5 @@ lerna-debug.log*
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# 방 seed 데이터 삽입 스크립트
+src/scripts/seed-rooms.ts

--- a/be/src/app.module.ts
+++ b/be/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -7,6 +8,7 @@ import databaseConfig from './providers/database/database.config';
 import { ChatModule } from './modules/chat/chat.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { RedisModule } from './providers/redis/redis.module';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 
 @Module({
   imports: [
@@ -17,6 +19,12 @@ import { RedisModule } from './providers/redis/redis.module';
     AuthModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: TransformInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/be/src/app.module.ts
+++ b/be/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_INTERCEPTOR, APP_FILTER } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -9,6 +9,7 @@ import { ChatModule } from './modules/chat/chat.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { RedisModule } from './providers/redis/redis.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 @Module({
   imports: [
@@ -24,6 +25,10 @@ import { TransformInterceptor } from './common/interceptors/transform.intercepto
     {
       provide: APP_INTERCEPTOR,
       useClass: TransformInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
     },
   ],
 })

--- a/be/src/common/decorators/api-response-message.decorator.ts
+++ b/be/src/common/decorators/api-response-message.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const API_RESPONSE_MESSAGE_KEY = 'api_response_message';
+
+/**
+ * API 응답 메시지를 커스터마이징하는 데코레이터
+ * @param message 커스텀 응답 메시지
+ */
+export const ApiResponseMessage = (message: string) => SetMetadata(API_RESPONSE_MESSAGE_KEY, message);

--- a/be/src/common/filters/http-exception.filter.ts
+++ b/be/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,59 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+
+/**
+ * HTTP 예외를 일관된 형식으로 변환하는 Exception Filter
+ * 모든 HTTP 예외를 { success: false, message: string } 형식으로 변환
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+      const exceptionResponse = exception.getResponse();
+
+      // 응답이 객체인 경우
+      if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
+        // 이미 success, message 구조를 가진 경우 그대로 사용
+        if ('success' in exceptionResponse && 'message' in exceptionResponse) {
+          response.status(status).json(exceptionResponse);
+          return;
+        }
+
+        // NestJS 기본 형식: { statusCode, message, error }
+        if ('message' in exceptionResponse) {
+          const msg = (exceptionResponse as { message: string | string[] }).message;
+          message = Array.isArray(msg) ? msg.join(', ') : msg;
+        }
+      } else {
+        // 문자열 응답인 경우
+        message = String(exceptionResponse);
+      }
+    } else if (exception instanceof Error) {
+      // 일반 JavaScript 에러
+      message = exception.message || message;
+      this.logger.error(`예상치 못한 에러 발생: ${exception.message}`, exception.stack);
+    }
+
+    // 에러 로그 기록
+    this.logger.error(
+      `HTTP ${status} Error: ${message} - ${request.method} ${request.url}`,
+      exception instanceof Error ? exception.stack : undefined,
+    );
+
+    // 일관된 에러 응답 형식
+    response.status(status).json({
+      success: false,
+      message,
+    });
+  }
+}

--- a/be/src/common/interceptors/transform.interceptor.ts
+++ b/be/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,62 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { API_RESPONSE_MESSAGE_KEY } from '../decorators/api-response-message.decorator';
+
+export interface Response<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+/**
+ * 응답 형식을 통일하는 Interceptor
+ * 컨트롤러에서 반환하는 데이터를 { success, message, data } 형식으로 자동 변환
+ */
+@Injectable()
+export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> {
+  constructor(private reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
+    return next.handle().pipe(
+      map((data) => {
+        // 이미 success, message, data 구조를 가진 경우 그대로 반환
+        if (data && typeof data === 'object' && 'success' in data && 'message' in data && 'data' in data) {
+          return data;
+        }
+
+        // 커스텀 메시지가 있는지 확인
+        const customMessage = this.reflector.getAllAndOverride<string>(API_RESPONSE_MESSAGE_KEY, [
+          context.getHandler(),
+          context.getClass(),
+        ]);
+
+        // 기본 응답 형식으로 변환
+        return {
+          success: true,
+          message: customMessage || this.getDefaultMessage(context),
+          data: data ?? null,
+        };
+      }),
+    );
+  }
+
+  /**
+   * HTTP 메서드에 따른 기본 메시지 반환
+   */
+  private getDefaultMessage(context: ExecutionContext): string {
+    const request = context.switchToHttp().getRequest();
+    const method = request.method;
+
+    const messages: Record<string, string> = {
+      GET: '조회에 성공했습니다.',
+      POST: '생성에 성공했습니다.',
+      PUT: '수정에 성공했습니다.',
+      PATCH: '수정에 성공했습니다.',
+      DELETE: '삭제에 성공했습니다.',
+    };
+
+    return messages[method] || '요청이 성공적으로 처리되었습니다.';
+  }
+}

--- a/be/src/common/interceptors/transform.interceptor.ts
+++ b/be/src/common/interceptors/transform.interceptor.ts
@@ -1,7 +1,7 @@
-import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler, HttpStatus } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { API_RESPONSE_MESSAGE_KEY } from '../decorators/api-response-message.decorator';
 
 export interface Response<T> {
@@ -13,12 +13,15 @@ export interface Response<T> {
 /**
  * 응답 형식을 통일하는 Interceptor
  * 컨트롤러에서 반환하는 데이터를 { success, message, data } 형식으로 자동 변환
+ * 빈 배열인 경우 204 No Content 상태 코드 설정
  */
 @Injectable()
 export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> {
   constructor(private reflector: Reflector) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
+    const response = context.switchToHttp().getResponse();
+
     return next.handle().pipe(
       map((data) => {
         // 이미 success, message, data 구조를 가진 경우 그대로 반환
@@ -39,12 +42,22 @@ export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> 
           data: data ?? null,
         };
       }),
+      tap((responseData) => {
+        // data가 객체이고 rooms 배열이 비어있으면 204 No Content 설정
+        if (
+          responseData?.data &&
+          typeof responseData.data === 'object' &&
+          'rooms' in responseData.data &&
+          Array.isArray(responseData.data.rooms) &&
+          responseData.data.rooms.length === 0
+        ) {
+          response.status(HttpStatus.NO_CONTENT);
+        }
+      }),
     );
   }
 
-  /**
-   * HTTP 메서드에 따른 기본 메시지 반환
-   */
+  // HTTP 메서드에 따른 기본 메시지 반환
   private getDefaultMessage(context: ExecutionContext): string {
     const request = context.switchToHttp().getRequest();
     const method = request.method;

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -211,6 +211,10 @@ export const LOG = {
       message: `참여자 수 조회 실패 (roomId: ${roomId}): ${error}`,
       level: 'error',
     }),
+    LOCAL_ROOMS_FETCH_ERROR: (error: string): LogMessage => ({
+      message: `로컬 방 목록 조회 실패: ${error}`,
+      level: 'error',
+    }),
   },
 } as const;
 

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -215,6 +215,10 @@ export const LOG = {
       message: `로컬 방 목록 조회 실패: ${error}`,
       level: 'error',
     }),
+    LOCAL_ROOMS_SEARCH_ERROR: (error: string): LogMessage => ({
+      message: `로컬 방 검색 실패: ${error}`,
+      level: 'error',
+    }),
   },
 } as const;
 

--- a/be/src/main.ts
+++ b/be/src/main.ts
@@ -31,6 +31,8 @@ async function bootstrap() {
     }),
   );
 
+  // 전역 Interceptor는 AppModule의 APP_INTERCEPTOR provider로 등록됨
+
   // Redis WebSocket 어댑터 연결 (공유 Redis 클라이언트 사용)
   const redisClient = app.get(REDIS_CLIENT);
   const redisIoAdapter = new RedisIoAdapter(app);

--- a/be/src/modules/room/dto/room.dto.ts
+++ b/be/src/modules/room/dto/room.dto.ts
@@ -11,3 +11,21 @@ export class RoomLeaveDto {
   @IsNotEmpty()
   roomId: string;
 }
+
+// 방 목록의 각각의 항목 dto
+export interface RoomListItemDto {
+  id: string;
+  title: string;
+  tags: string[];
+  current_participants: number;
+  max_participants: number;
+  is_mic_available: boolean;
+  is_private: boolean;
+  participant_profile_images: string[];
+  create_date: string;
+}
+
+// 방 목록 응답 시 사용하는 dto
+export interface RoomListResponseDto {
+  rooms: RoomListItemDto[];
+}

--- a/be/src/modules/room/dto/room.dto.ts
+++ b/be/src/modules/room/dto/room.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class RoomJoinDto {
   @IsString()
@@ -28,4 +28,11 @@ export interface RoomListItemDto {
 // 방 목록 응답 시 사용하는 dto
 export interface RoomListResponseDto {
   rooms: RoomListItemDto[];
+}
+
+// 방 검색 조회 시 사용하는 dto
+export class RoomSearchQueryDto {
+  @IsString()
+  @IsOptional()
+  keyword?: string;
 }

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpException, HttpStatus, Query } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { RoomService } from './room.service';
 import { RoomListResponseDto, RoomSearchQueryDto } from './dto/room.dto';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
@@ -11,36 +11,16 @@ export class RoomController {
   @Get('all')
   @ApiResponseMessage('방 목록 조회에 성공 했습니다.')
   async getLocalRooms(): Promise<RoomListResponseDto> {
-    try {
-      const rooms = await this.roomService.getLocalRooms();
-      return { rooms };
-    } catch (error) {
-      throw new HttpException(
-        {
-          success: false,
-          message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    const rooms = await this.roomService.getLocalRooms();
+    return { rooms };
   }
 
   //로컬 방 검색 -> GET /api/rooms/search?keyword=검색어
   @Get('search')
   @ApiResponseMessage('방 검색 조회에 성공 했습니다.')
   async searchLocalRooms(@Query() query: RoomSearchQueryDto): Promise<RoomListResponseDto> {
-    try {
-      const keyword = query.keyword || '';
-      const rooms = await this.roomService.searchLocalRooms(keyword);
-      return { rooms };
-    } catch (error) {
-      throw new HttpException(
-        {
-          success: false,
-          message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    const keyword = query.keyword || '';
+    const rooms = await this.roomService.searchLocalRooms(keyword);
+    return { rooms };
   }
 }

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, HttpException, HttpStatus, Query } from '@nestjs/common';
 import { RoomService } from './room.service';
-import { RoomListResponseDto } from './dto/room.dto';
+import { RoomListResponseDto, RoomSearchQueryDto } from './dto/room.dto';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
 
 @Controller('rooms')
@@ -13,6 +13,25 @@ export class RoomController {
   async getLocalRooms(): Promise<RoomListResponseDto> {
     try {
       const rooms = await this.roomService.getLocalRooms();
+      return { rooms };
+    } catch (error) {
+      throw new HttpException(
+        {
+          success: false,
+          message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  //로컬 방 검색 -> GET /api/rooms/search?keyword=검색어
+  @Get('search')
+  @ApiResponseMessage('방 검색 조회에 성공 했습니다.')
+  async searchLocalRooms(@Query() query: RoomSearchQueryDto): Promise<RoomListResponseDto> {
+    try {
+      const keyword = query.keyword || '';
+      const rooms = await this.roomService.searchLocalRooms(keyword);
       return { rooms };
     } catch (error) {
       throw new HttpException(

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, HttpException, HttpStatus } from '@nestjs/common';
 import { RoomService } from './room.service';
 import { RoomListResponseDto, RoomSearchQueryDto } from './dto/room.dto';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
@@ -22,5 +22,11 @@ export class RoomController {
     const keyword = query.keyword || '';
     const rooms = await this.roomService.searchLocalRooms(keyword);
     return { rooms };
+  }
+
+  // postman 에러 테스트용 -> GET /api/rooms/test/error
+  @Get('test/error')
+  async testError(): Promise<void> {
+    throw new HttpException('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -1,4 +1,27 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import { RoomService } from './room.service';
+import { RoomListResponseDto } from './dto/room.dto';
+import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
 
 @Controller('rooms')
-export class RoomController {}
+export class RoomController {
+  constructor(private readonly roomService: RoomService) {}
+
+  //로컬 방 목록 조회 -> GET /api/rooms/all
+  @Get('all')
+  @ApiResponseMessage('방 목록 조회에 성공 했습니다.')
+  async getLocalRooms(): Promise<RoomListResponseDto> {
+    try {
+      const rooms = await this.roomService.getLocalRooms();
+      return { rooms };
+    } catch (error) {
+      throw new HttpException(
+        {
+          success: false,
+          message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleInit, HttpException, HttpStatus } from '@nestjs/common';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
@@ -328,7 +328,7 @@ export class RoomService implements OnModuleInit {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.ROOM.LOCAL_ROOMS_FETCH_ERROR(errorMessage));
-      throw error;
+      throw new HttpException('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -362,7 +362,7 @@ export class RoomService implements OnModuleInit {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.ROOM.LOCAL_ROOMS_SEARCH_ERROR(errorMessage));
-      throw error;
+      throw new HttpException('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -236,4 +236,99 @@ export class RoomService implements OnModuleInit {
       return 0;
     }
   }
+
+  // 로컬 방 전체 목록 조회
+  async getLocalRooms(): Promise<
+    Array<{
+      id: string;
+      title: string;
+      tags: string[];
+      current_participants: number;
+      max_participants: number;
+      is_mic_available: boolean;
+      is_private: boolean;
+      participant_profile_images: string[];
+      create_date: string;
+    }>
+  > {
+    try {
+      const roomKeys = await this.redisClient.keys('room:*');
+
+      // room:{roomId} 형식의 방 키만 필터링
+      const mainRoomKeys = roomKeys.filter((key) => {
+        const parts = key.split(':');
+        return parts.length === 2;
+      });
+
+      const localRooms: Array<{
+        id: string;
+        title: string;
+        tags: string[];
+        current_participants: number;
+        max_participants: number;
+        is_mic_available: boolean;
+        is_private: boolean;
+        participant_profile_images: string[];
+        create_date: string;
+      }> = [];
+
+      for (const roomKey of mainRoomKeys) {
+        const roomId = roomKey.split(':')[1];
+
+        const roomType = await this.getRoomType(roomId);
+        if (roomType !== ROOM_TYPE.LOCAL) {
+          continue;
+        }
+
+        const roomData = await this.redisClient.hGetAll(roomKey);
+        if (!roomData || Object.keys(roomData).length === 0) {
+          continue;
+        }
+
+        const tags = await this.redisClient.sMembers(`room:${roomId}:tags`);
+
+        // 멤버 목록 조회
+        const memberUserIds = await this.redisClient.hKeys(`room:${roomId}:members`);
+        const participantProfileImages: string[] = [];
+
+        // 프로필 이미지 -> UI에 5개만 표시
+        const profileImageLimit = 5;
+        for (const userId of memberUserIds.slice(0, profileImageLimit)) {
+          try {
+            const memberInfo = await this.redisClient.hGetAll(`room:${roomId}:members:${userId}`);
+            if (memberInfo?.profile_image) {
+              participantProfileImages.push(memberInfo.profile_image);
+            }
+          } catch (error) {
+            this.logger.warn(`멤버 정보 조회 실패 (roomId: ${roomId}, userId: ${userId})`);
+          }
+        }
+
+        localRooms.push({
+          id: roomId,
+          title: roomData.title || '',
+          tags: tags || [],
+          current_participants: parseInt(roomData.current_participants || '0', 10),
+          max_participants: parseInt(roomData.max_participants || '0', 10),
+          is_mic_available: roomData.is_mic_available === '1',
+          is_private: roomData.is_private === '1',
+          participant_profile_images: participantProfileImages,
+          create_date: roomData.create_date || new Date().toISOString(),
+        });
+      }
+
+      // 최신순 정렬
+      localRooms.sort((a, b) => {
+        const dateA = new Date(a.create_date).getTime();
+        const dateB = new Date(b.create_date).getTime();
+        return dateB - dateA;
+      });
+
+      return localRooms;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logMessage(this.logger, LOG.ROOM.LOCAL_ROOMS_FETCH_ERROR(errorMessage));
+      throw error;
+    }
+  }
 }

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -331,4 +331,38 @@ export class RoomService implements OnModuleInit {
       throw error;
     }
   }
+
+  // 로컬 방 검색 조회
+  async searchLocalRooms(keyword: string): Promise<
+    Array<{
+      id: string;
+      title: string;
+      tags: string[];
+      current_participants: number;
+      max_participants: number;
+      is_mic_available: boolean;
+      is_private: boolean;
+      participant_profile_images: string[];
+      create_date: string;
+    }>
+  > {
+    try {
+      const allRooms = await this.getLocalRooms();
+      // keyword가 없으면 모든 로컬 룸 반환
+      if (!keyword || keyword.trim() === '') {
+        return allRooms;
+      }
+
+      const searchKeyword = keyword.trim().toLowerCase();
+      const filteredRooms = allRooms.filter((room) => {
+        return room.title.toLowerCase().includes(searchKeyword);
+      });
+
+      return filteredRooms;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logMessage(this.logger, LOG.ROOM.LOCAL_ROOMS_SEARCH_ERROR(errorMessage));
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

- 로컬 방 전체 목록 조회 구현
  - <img width="1075" height="620" alt="image" src="https://github.com/user-attachments/assets/7506c6df-27cb-4e39-9929-db0f03525429" />

- 로컬 방 검색 조회 구현
  - <img width="1064" height="627" alt="image" src="https://github.com/user-attachments/assets/658cac92-b323-4334-b7e4-78a1bceec13e" />

- http 표준 응답에 맞게 응답 형식 통일
  - interceptor 구현 -> 전역 interceptor로 등록
- exception filter 처리
  - <img width="1068" height="492" alt="image" src="https://github.com/user-attachments/assets/bb1582f4-36be-4742-a327-e9c8abeedf5f" />

---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- in progress #59

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [API 응답 형식 통일 interceptor](https://rapid-bubble-113.notion.site/API-interceptor-2e7207f233418053a508f07f674c8a97?source=copy_link)
- [HTTP Exception Filter 추가](https://rapid-bubble-113.notion.site/HTTP-Exception-Filter-2e7207f2334180f884c6ea2b9b0cc219?source=copy_link)

---


### ✅ 기타 메모
> 기타 전달하고 싶은 내용이 있다면 자유롭게 작성

- 로컬 방 목록 조회 커밋이 [빈 배열 응답 시 204 No Content 상태코드 응답](https://github.com/boostcampwm2025/web26-2Ryuk/commit/0e19676da382b3df8ddf27fccdba9b1f4447c439) 커밋 부분에 함께 들어가있습니다.