### PR TITLE
[Refactor/Feat] userId UUID로 통일, mysql 조회로 수정, 로컬 방 채팅 구현, 글로벌 채팅 입장 시 이전 30개 채팅 기록 보여주기

### DIFF
--- a/be/package.json
+++ b/be/package.json
@@ -27,6 +27,8 @@
     "migration:revert": "DB_HOST=localhost DB_PORT=3307 pnpm typeorm migration:revert -d src/providers/database/data-source.ts",
     "migration:revert:prod": "NODE_ENV=production pnpm typeorm:prod migration:revert -d dist/providers/database/data-source.js",
     "migration:create": "pnpm typeorm migration:create src/providers/database/migrations/init",
+    "seed:rooms": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-rooms.ts",
+    "seed:rooms:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-rooms.ts",
     "seed:users": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts",
     "seed:users:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts"
   },

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -12,7 +12,6 @@ import { Logger, Inject, UsePipes, ValidationPipe, BadRequestException, UseFilte
 import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { RoomService } from '@src/modules/room/room.service';
-import { MockAuthService } from '@src/modules/auth/mock-auth.service';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
@@ -42,7 +41,6 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     private readonly roomService: RoomService,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
-    private readonly mockAuthService: MockAuthService,
   ) {}
 
   /**
@@ -60,7 +58,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // 디버깅: 인증 정보 확인
       this.logger.debug(`Connection - socketId: ${client.id}, userId: ${userId}, authenticated: ${isAuthenticated}`);
 
-      // 연결 로그
+      // 연결 로그 (userId만 사용, MySQL 조회 없음)
       try {
         logMessage(this.logger, LOG.WS.CONNECT(client.id, userId));
       } catch (logError) {
@@ -103,7 +101,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
         }
       }
 
-      // 최종 연결 상태 로그
+      // 최종 연결 상태 로그 (userId만 사용, MySQL 조회 없음)
       if (isAuthenticated && userId) {
         try {
           logMessage(this.logger, LOG.WS.AUTH_CONNECT(userId));

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -94,9 +94,20 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
             // 참여자 수 조회 및 브로드캐스트 (항상 최신 상태 전송)
             const currentParticipants = await this.roomService.getCurrentParticipants(globalRoomId);
             await this.roomService.notifyParticipantsUpdated(this.server, globalRoomId, currentParticipants);
+
+            // 글로벌 룸 최신 메시지 전송
+            await this.sendGlobalChatRecents(client, globalRoomId, userId);
           } catch (checkError) {
             const errorMessage = checkError instanceof Error ? checkError.message : String(checkError);
             logMessage(this.logger, LOG.WS.ROOM_PARTICIPATION_CHECK_ERROR(errorMessage));
+          }
+        } else {
+          // 인증되지 않은 사용자도 최신 메시지 조회 가능 (is_me는 모두 false)
+          try {
+            await this.sendGlobalChatRecents(client, globalRoomId, null);
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.error(`글로벌 채팅 최신 메시지 전송 실패: ${errorMessage}`);
           }
         }
       }
@@ -191,6 +202,35 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.WS.LOGOUT_ERROR(errorMessage));
+    }
+  }
+
+  // 글로벌 룸 입장 시 최신 메시지 전송
+  private async sendGlobalChatRecents(client: Socket, roomId: string, userId: string | null): Promise<void> {
+    try {
+      const recents = await this.roomService.getGlobalChatRecents(roomId);
+
+      const messages = recents.map((msg) => ({
+        message: msg.content,
+        sender: {
+          sender_id: msg.sender_id,
+          nickname: msg.nickname,
+          profile_image: msg.profile_image,
+          is_me: userId ? msg.sender_id === userId : false,
+        },
+        timestamp: msg.create_date,
+      }));
+
+      client.emit('chat:global:recents', {
+        messages,
+      });
+
+      this.logger.debug(
+        `글로벌 채팅 최신 메시지 전송: roomId=${roomId}, userId=${userId || 'anonymous'}, count=${recents.length}`,
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`글로벌 채팅 최신 메시지 전송 실패: ${errorMessage}`);
     }
   }
 }

--- a/be/src/common/utils/user-id.ts
+++ b/be/src/common/utils/user-id.ts
@@ -1,0 +1,36 @@
+import { createHash } from 'crypto';
+
+/**
+ * UUID 형식인지 확인
+ * 형식: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (8-4-4-4-12)
+ */
+export function isUuid(value: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(value);
+}
+
+/**
+ * 문자열을 UUID 형식으로 변환
+ * - 이미 UUID 형식이면 그대로 반환 (실제 운영 환경)
+ * - Mock ID('J001' 형식)이면 UUID로 변환 (개발 환경)
+ *
+ * NOTE: Mock ID 변환은 결정적(deterministic)이어야 하므로 MD5 기반으로 고정 매핑을 만든다.
+ */
+export function toUuid(value: string): string {
+  if (isUuid(value)) return value;
+
+  const hash = createHash('md5').update(value).digest('hex');
+  return `${hash.substring(0, 8)}-${hash.substring(8, 12)}-${hash.substring(12, 16)}-${hash.substring(16, 20)}-${hash.substring(20, 32)}`;
+}
+
+/**
+ * mockUsers 배열을 기반으로 UUID -> 원본 mock id(J001) 매핑을 생성
+ * (MockAuthService에서 UUID로 로그인 요청이 들어올 때 역조회 용도)
+ */
+export function buildUuidToMockIdMap<T extends { id: string }>(users: readonly T[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const user of users) {
+    map.set(toUuid(user.id), user.id);
+  }
+  return map;
+}

--- a/be/src/modules/auth/auth.controller.ts
+++ b/be/src/modules/auth/auth.controller.ts
@@ -1,10 +1,14 @@
 import { Controller, Post, Get, Body, Headers, UsePipes, ValidationPipe } from '@nestjs/common';
+import { AuthService } from './auth.service';
 import { MockAuthService } from './mock-auth.service';
 import { MockLoginDto, MockUserResponseDto } from './dto/mock-login.dto';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly mockAuthService: MockAuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly mockAuthService: MockAuthService,
+  ) {}
 
   /**
    * 개발용 Mock 로그인 (토큰 발급)
@@ -54,9 +58,10 @@ export class AuthController {
   /**
    * 현재 인증된 사용자 정보 조회
    * GET /api/auth/me
+   * MySQL에서 실제 사용자 정보 조회
    */
   @Get('me')
-  getMe(@Headers('authorization') authHeader?: string) {
+  async getMe(@Headers('authorization') authHeader?: string) {
     if (!authHeader) return { success: false, message: '인증이 필요합니다.' };
 
     const token = authHeader.replace('Bearer ', '');
@@ -64,8 +69,8 @@ export class AuthController {
 
     if (!payload) return { success: false, message: '유효하지 않은 토큰입니다.' };
 
-    const user = this.mockAuthService.getMockUserById(payload.userId);
-    if (!user) return { success: false, message: '사용자를 찾을 수 없습니다.' };
+    // Service를 통해 MySQL에서 실제 사용자 정보 조회
+    const user = await this.authService.getUserById(payload.userId);
 
     return {
       id: user.id,

--- a/be/src/modules/auth/auth.module.ts
+++ b/be/src/modules/auth/auth.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 import { MockAuthService } from './mock-auth.service';
+import { User } from '../user/user.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [AuthController],
-  providers: [MockAuthService],
-  exports: [MockAuthService],
+  providers: [AuthService, MockAuthService],
+  exports: [AuthService, MockAuthService],
 })
 export class AuthModule {}

--- a/be/src/modules/auth/auth.service.ts
+++ b/be/src/modules/auth/auth.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../user/user.entity';
+import { toUuid } from '@src/common/utils/user-id';
+
+@Injectable()
+export class AuthService {
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
+
+  /**
+   * userId로 사용자 정보 조회
+   * @param userId 원본 ID('J001') 또는 UUID 형식
+   * @returns 사용자 정보 (id, nickname, profile_image)
+   * @throws NotFoundException 사용자를 찾을 수 없는 경우
+   */
+  async getUserById(userId: string): Promise<{ id: string; nickname: string; profile_image: string | null }> {
+    const uuid = toUuid(userId);
+    const user = await this.userRepository.findOne({
+      where: { id: uuid },
+      select: ['id', 'nickname', 'profile_image'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      profile_image: user.profile_image,
+    };
+  }
+
+  /**
+   * userId로 사용자 정보 조회 (role 포함)
+   * 채팅 등에서 사용자 정보와 role이 모두 필요한 경우 사용
+   * @param userId 원본 ID('J001') 또는 UUID 형식
+   * @returns 사용자 정보 (id, nickname, profile_image, role)
+   * @throws NotFoundException 사용자를 찾을 수 없는 경우
+   */
+  async getUserWithRole(userId: string): Promise<{
+    id: string;
+    nickname: string;
+    profile_image: string | null;
+    role: string;
+  }> {
+    const uuid = toUuid(userId);
+    const user = await this.userRepository.findOne({
+      where: { id: uuid },
+      select: ['id', 'nickname', 'profile_image', 'role'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      profile_image: user.profile_image,
+      role: user.role,
+    };
+  }
+}

--- a/be/src/modules/auth/mock-auth.service.ts
+++ b/be/src/modules/auth/mock-auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import mockUsersData from '../../mocks/users.js';
+import { buildUuidToMockIdMap, toUuid } from '@src/common/utils/user-id';
 
 export interface MockUser {
   id: string;
@@ -17,6 +18,8 @@ export interface MockUser {
 export class MockAuthService {
   // 개발용 Mock 사용자 목록 (users.js에서 로드)
   private readonly mockUsers: MockUser[];
+  // UUID → 원본 ID 매핑 (빠른 조회를 위한 캐시)
+  private readonly uuidToIdMap: Map<string, string>;
 
   constructor() {
     // JSON 데이터를 MockUser 형식으로 변환 (Date 객체 변환)
@@ -25,6 +28,9 @@ export class MockAuthService {
       create_date: new Date(user.create_date),
       update_date: user.update_date ? new Date(user.update_date) : null,
     }));
+
+    // UUID → 원본 ID 매핑 생성
+    this.uuidToIdMap = buildUuidToMockIdMap(this.mockUsers);
   }
 
   /**
@@ -38,6 +44,7 @@ export class MockAuthService {
 
   /**
    * Mock 토큰에서 userId 추출
+   * 원본 ID('J001') 또는 UUID 형식 모두 지원
    * @returns { userId: string } | null
    */
   verifyMockToken(token: string): { userId: string } | null {
@@ -48,11 +55,12 @@ export class MockAuthService {
 
     const userId = match[1];
 
-    // Mock 사용자 목록에 있는지 확인
-    const userExists = this.mockUsers.some((user) => user.id === userId);
-    if (!userExists) return null;
+    // 원본 ID 형식인지 확인
+    const user = this.getMockUserById(userId);
+    if (!user) return null;
 
-    return { userId };
+    // 원본 ID 반환 (일관성을 위해)
+    return { userId: user.id };
   }
 
   /**
@@ -64,8 +72,19 @@ export class MockAuthService {
 
   /**
    * userId로 Mock 사용자 조회
+   * 원본 ID('J001') 또는 UUID 형식 모두 지원
    */
   getMockUserById(userId: string): MockUser | undefined {
-    return this.mockUsers.find((user) => user.id === userId);
+    // 원본 ID 형식인지 확인 (J001, J002 등)
+    const originalUser = this.mockUsers.find((user) => user.id === userId);
+    if (originalUser) return originalUser;
+
+    // UUID 형식인 경우 원본 ID로 변환
+    const originalId = this.uuidToIdMap.get(toUuid(userId));
+    if (originalId) {
+      return this.mockUsers.find((user) => user.id === originalId);
+    }
+
+    return undefined;
   }
 }

--- a/be/src/modules/auth/mock-auth.service.ts
+++ b/be/src/modules/auth/mock-auth.service.ts
@@ -73,6 +73,9 @@ export class MockAuthService {
   /**
    * userId로 Mock 사용자 조회
    * 원본 ID('J001') 또는 UUID 형식 모두 지원
+   *
+   * 주의: 이 메서드는 Mock 로그인/토큰 검증용으로만 사용됩니다.
+   * 실제 사용자 정보 조회는 MySQL에서 수행해야 합니다.
    */
   getMockUserById(userId: string): MockUser | undefined {
     // 원본 ID 형식인지 확인 (J001, J002 등)

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -127,8 +127,16 @@ export class ChatGateway {
         return;
       }
 
+      const user = await this.authService.getUserWithRole(userId);
+
+      const senderInfo = {
+        role: user.role,
+        nickname: user.nickname,
+        profile_image: user.profile_image,
+      };
+
       // 메시지 브로드캐스트
-      await this.chatService.broadcastRoomChat(this.server, dto.room_id, userId, dto.message);
+      await this.chatService.broadcastRoomChat(this.server, dto.room_id, userId, dto.message, senderInfo, client.id);
     } catch (error) {
       // ValidationPipe 에러 처리
       if (error instanceof BadRequestException) {

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -5,7 +5,7 @@ import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { ChatService } from './chat.service';
 import { RoomService } from '@src/modules/room/room.service';
-import { MockAuthService } from '@src/modules/auth/mock-auth.service';
+import { AuthService } from '@src/modules/auth/auth.service';
 import { GlobalChatSendDto, RoomChatSendDto } from './dto/chat-message.dto';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
@@ -35,8 +35,8 @@ export class ChatGateway {
   constructor(
     private readonly chatService: ChatService,
     private readonly roomService: RoomService,
+    private readonly authService: AuthService,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
-    private readonly mockAuthService: MockAuthService,
   ) {}
 
   // 글로벌 채팅 메시지 수신 및 브로드캐스트 (인증되지 않은 사용자는 수신만)
@@ -61,17 +61,13 @@ export class ChatGateway {
         return;
       }
 
-      // 사용자 정보 조회 (MockAuthService 사용, 나중에 UserService로 교체)
-      const mockUser = this.mockAuthService?.getMockUserById(userId);
-      if (!mockUser) {
-        client.emit('error', { message: '사용자 정보를 찾을 수 없습니다.' });
-        return;
-      }
+      // Service를 통해 MySQL에서 실제 사용자 정보 조회
+      const user = await this.authService.getUserWithRole(userId);
 
       const senderInfo = {
-        role: mockUser.role,
-        nickname: mockUser.nickname,
-        profile_image: mockUser.profile_image,
+        role: user.role,
+        nickname: user.nickname,
+        profile_image: user.profile_image,
       };
 
       // 메시지 브로드캐스트 (is_me 구분하여 전송)
@@ -124,15 +120,15 @@ export class ChatGateway {
       }
 
       // 권한 검증: 해당 방의 참여자인지 확인
-      const isInRoom = await this.roomService.isUserInRoom(userId, dto.roomId);
+      const isInRoom = await this.roomService.isUserInRoom(userId, dto.room_id);
       if (!isInRoom) {
-        logMessage(this.logger, LOG.CHAT.NOT_MEMBER_SEND(userId, dto.roomId));
+        logMessage(this.logger, LOG.CHAT.NOT_MEMBER_SEND(userId, dto.room_id));
         client.emit('error', { message: '해당 방에 참여하지 않았습니다.' });
         return;
       }
 
       // 메시지 브로드캐스트
-      await this.chatService.broadcastRoomChat(this.server, dto.roomId, userId, dto.message);
+      await this.chatService.broadcastRoomChat(this.server, dto.room_id, userId, dto.message);
     } catch (error) {
       // ValidationPipe 에러 처리
       if (error instanceof BadRequestException) {

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Server } from 'socket.io';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
-import { GlobalChatMessageResponseDto } from './dto/chat-response.dto';
+import { GlobalChatMessageResponseDto, LocalChatMessageResponseDto } from './dto/chat-response.dto';
 
 @Injectable()
 export class ChatService {
@@ -68,16 +68,55 @@ export class ChatService {
   }
 
   // 방 채팅 메시지 브로드캐스트
-  async broadcastRoomChat(server: Server, roomId: string, userId: string, message: string): Promise<void> {
-    const data = {
-      roomId,
-      userId,
-      message,
-      timestamp: new Date().toISOString(),
+  async broadcastRoomChat(
+    server: Server,
+    roomId: string,
+    userId: string,
+    message: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    senderSocketId: string,
+  ): Promise<void> {
+    const timestamp = new Date().toISOString();
+
+    // 메시지를 보낸 사용자에게는 is_me: true로 전송
+    const responseToSender: LocalChatMessageResponseDto = {
+      event: 'chat:room:new-message',
+      data: {
+        room_id: roomId,
+        message,
+        sender: {
+          role: senderInfo.role,
+          nickname: senderInfo.nickname,
+          profile_image: senderInfo.profile_image,
+          is_me: true,
+        },
+        timestamp,
+      },
     };
 
-    // Socket.io room을 사용하여 해당 방의 참여자에게만 전송
-    server.to(roomId).emit('chat:room:new-message', data);
+    // 다른 사용자들에게는 is_me: false로 전송
+    const responseToOthers: LocalChatMessageResponseDto = {
+      event: 'chat:room:new-message',
+      data: {
+        room_id: roomId,
+        message,
+        sender: {
+          role: senderInfo.role,
+          nickname: senderInfo.nickname,
+          profile_image: senderInfo.profile_image,
+          is_me: false,
+        },
+        timestamp,
+      },
+    };
+
+    // 메시지를 보낸 클라이언트에게만 is_me: true로 전송
+    server.to(senderSocketId).emit(responseToSender.event, responseToSender.data);
+    this.logger.debug(`메시지 발신자에게 전송: socketId=${senderSocketId}, is_me=true`);
+
+    // 같은 방의 다른 클라이언트들에게는 is_me: false로 전송
+    server.to(roomId).except(senderSocketId).emit(responseToOthers.event, responseToOthers.data);
+    this.logger.debug(`다른 클라이언트들에게 브로드캐스트: roomId=${roomId}, except=${senderSocketId}, is_me=false`);
 
     logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
   }

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -1,11 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Inject } from '@nestjs/common';
 import { Server } from 'socket.io';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GlobalChatMessageResponseDto, LocalChatMessageResponseDto } from './dto/chat-response.dto';
+import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
+import { RedisClientType } from 'redis';
+import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
 
 @Injectable()
 export class ChatService {
   private readonly logger = new Logger(ChatService.name);
+
+  constructor(@Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType) {}
 
   /**
    * 글로벌 채팅 메시지 브로드캐스트
@@ -64,6 +69,11 @@ export class ChatService {
     server.to(roomId).except(senderSocketId).emit(responseToOthers.event, responseToOthers.data);
     this.logger.debug(`다른 클라이언트들에게 브로드캐스트: roomId=${roomId}, except=${senderSocketId}, is_me=false`);
 
+    // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+    if (roomId === GLOBAL_ROOM_ID) {
+      await this.saveGlobalChatMessage(roomId, userId, message, senderInfo, timestamp);
+    }
+
     logMessage(this.logger, LOG.CHAT.GLOBAL_BROADCAST(userId, message));
   }
 
@@ -119,5 +129,34 @@ export class ChatService {
     this.logger.debug(`다른 클라이언트들에게 브로드캐스트: roomId=${roomId}, except=${senderSocketId}, is_me=false`);
 
     logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
+  }
+
+  // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+  private async saveGlobalChatMessage(
+    roomId: string,
+    senderId: string,
+    content: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    createDate: string,
+  ): Promise<void> {
+    try {
+      const recentsKey = `room:${roomId}:recents`;
+      const messageData = {
+        sender_id: senderId,
+        content,
+        nickname: senderInfo.nickname,
+        profile_image: senderInfo.profile_image || '',
+        create_date: createDate,
+      };
+
+      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
+      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
+
+      // 최신 30개만 유지 (오래된 메시지 제거)
+      await this.redisClient.lTrim(recentsKey, -30, -1);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`글로벌 채팅 메시지 저장 실패: ${errorMessage}`);
+    }
   }
 }

--- a/be/src/modules/chat/dto/chat-message.dto.ts
+++ b/be/src/modules/chat/dto/chat-message.dto.ts
@@ -9,7 +9,7 @@ export class GlobalChatSendDto {
 export class RoomChatSendDto {
   @IsString()
   @IsNotEmpty()
-  roomId: string;
+  room_id: string;
 
   @IsString()
   @IsNotEmpty()

--- a/be/src/modules/chat/dto/chat-response.dto.ts
+++ b/be/src/modules/chat/dto/chat-response.dto.ts
@@ -17,7 +17,7 @@ export interface GlobalChatMessageResponseDto {
 export interface LocalChatMessageResponseDto {
   event: 'chat:room:new-message';
   data: {
-    roomId: string;
+    room_id: string;
     message: string;
     sender: {
       role: string;

--- a/be/src/modules/room/dto/room.dto.ts
+++ b/be/src/modules/room/dto/room.dto.ts
@@ -16,13 +16,13 @@ export class JoinRoomRequestDto {
 export class RoomJoinDto extends JoinRoomRequestDto {
   @IsString()
   @IsNotEmpty()
-  roomId: string;
+  room_id: string;
 }
 
 export class RoomLeaveDto {
   @IsString()
   @IsNotEmpty()
-  roomId: string;
+  room_id: string;
 }
 
 export class RoomRequestDto {

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -138,6 +138,6 @@ export class RoomController {
 
     await this.roomService.validateJoinRoom(roomId, payload.userId, dto.password);
 
-    return { roomId };
+    return { room_id: roomId };
   }
 }

--- a/be/src/modules/room/room.gateway.ts
+++ b/be/src/modules/room/room.gateway.ts
@@ -1,10 +1,12 @@
 import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { Logger, Inject, ValidationPipe, BadRequestException, UsePipes, UseFilters } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { RoomService } from './room.service';
-import { MockAuthService } from '@src/modules/auth/mock-auth.service';
+import { User } from '@src/modules/user/user.entity';
 import { RoomJoinDto, RoomLeaveDto } from './dto/room.dto';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
@@ -34,7 +36,7 @@ export class RoomGateway {
   constructor(
     private readonly roomService: RoomService,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
-    private readonly mockAuthService: MockAuthService,
+    @InjectRepository(User) private readonly userRepository: Repository<User>,
   ) {}
 
   /**
@@ -105,17 +107,22 @@ export class RoomGateway {
       client.emit('room:joined', { roomId: dto.roomId });
 
       // 브로드캐스트: 사용자 정보 및 현재 참여자 수 조회
-      const mockUser = this.mockAuthService.getMockUserById(userId);
+      // MySQL에서 사용자 정보 조회 (nickname, profile_image)
+      const user = await this.userRepository.findOne({
+        where: { id: userId },
+        select: ['nickname', 'profile_image'],
+      });
+
       const currentParticipants = await this.roomService.getCurrentParticipants(dto.roomId);
 
-      if (mockUser) {
+      if (user) {
         await this.roomService.notifyUserJoined(
           this.server,
           dto.roomId,
           {
             userId,
-            nickname: mockUser.nickname,
-            profile_image: mockUser.profile_image,
+            nickname: user.nickname,
+            profile_image: user.profile_image,
           },
           currentParticipants,
         );

--- a/be/src/modules/room/room.gateway.ts
+++ b/be/src/modules/room/room.gateway.ts
@@ -1,12 +1,10 @@
 import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { Logger, Inject, ValidationPipe, BadRequestException, UsePipes, UseFilters } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { RoomService } from './room.service';
-import { User } from '@src/modules/user/user.entity';
+import { AuthService } from '@src/modules/auth/auth.service';
 import { RoomJoinDto, RoomLeaveDto } from './dto/room.dto';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
@@ -35,8 +33,8 @@ export class RoomGateway {
 
   constructor(
     private readonly roomService: RoomService,
+    private readonly authService: AuthService,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
-    @InjectRepository(User) private readonly userRepository: Repository<User>,
   ) {}
 
   /**
@@ -52,7 +50,7 @@ export class RoomGateway {
     const isAuthenticated = client.data.authenticated;
 
     // 글로벌 방 입장 요청은 무시 (연결 시 자동 입장됨)
-    if (dto.roomId === GLOBAL_ROOM_ID) {
+    if (dto.room_id === GLOBAL_ROOM_ID) {
       return;
     }
 
@@ -64,71 +62,65 @@ export class RoomGateway {
     }
 
     // 방 타입 확인
-    const roomType = await this.roomService.getRoomType(dto.roomId);
+    const roomType = await this.roomService.getRoomType(dto.room_id);
 
     try {
       // 방 존재 여부 및 타입 확인
       if (roomType === null) {
-        logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.roomId));
+        logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.room_id));
         client.emit('error', { message: '존재하지 않는 방입니다.' });
         return;
       }
 
       // 권한 검증
-      const canJoin = await this.roomService.canUserJoinRoom(userId, dto.roomId);
+      const canJoin = await this.roomService.canUserJoinRoom(userId, dto.room_id);
       if (!canJoin) {
-        logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.roomId));
+        logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.room_id));
         client.emit('error', { message: '방 입장 권한이 없습니다.' });
         return;
       }
 
       // 이미 참여 중인지 확인
-      const isInRoom = await this.roomService.isUserInRoom(userId, dto.roomId);
+      const isInRoom = await this.roomService.isUserInRoom(userId, dto.room_id);
       if (isInRoom) {
-        logMessage(this.logger, LOG.ROOM.ALREADY_IN(userId, dto.roomId));
-        client.emit('room:joined', { roomId: dto.roomId });
+        logMessage(this.logger, LOG.ROOM.ALREADY_IN(userId, dto.room_id));
+        client.emit('room:joined', { room_id: dto.room_id });
         return;
       }
 
       // 기존 로컬 방 자동 퇴장 처리 (방 이동)
       const existingLocalRoom = await this.roomService.getUserLocalRoom(userId);
-      if (existingLocalRoom && existingLocalRoom !== dto.roomId) {
-        logMessage(this.logger, LOG.ROOM.JOIN_SWITCH(userId, existingLocalRoom, dto.roomId));
+      if (existingLocalRoom && existingLocalRoom !== dto.room_id) {
+        logMessage(this.logger, LOG.ROOM.JOIN_SWITCH(userId, existingLocalRoom, dto.room_id));
         await this.leaveRoomProcess(client, userId, existingLocalRoom);
       }
 
       // 논리적 상태 변경: 방에 참여
-      await this.roomService.joinRoom(userId, dto.roomId);
+      await this.roomService.joinRoom(userId, dto.room_id);
 
       // Socket.io room에 참여
-      client.join(dto.roomId);
+      client.join(dto.room_id);
 
       // 클라이언트에 입장 성공 알림 (ACK)
-      client.emit('room:joined', { roomId: dto.roomId });
+      client.emit('room:joined', { room_id: dto.room_id });
 
       // 브로드캐스트: 사용자 정보 및 현재 참여자 수 조회
-      // MySQL에서 사용자 정보 조회 (nickname, profile_image)
-      const user = await this.userRepository.findOne({
-        where: { id: userId },
-        select: ['nickname', 'profile_image'],
-      });
+      // Service를 통해 MySQL에서 사용자 정보 조회
+      const user = await this.authService.getUserById(userId);
+      const currentParticipants = await this.roomService.getCurrentParticipants(dto.room_id);
 
-      const currentParticipants = await this.roomService.getCurrentParticipants(dto.roomId);
+      await this.roomService.notifyUserJoined(
+        this.server,
+        dto.room_id,
+        {
+          userId,
+          nickname: user.nickname,
+          profile_image: user.profile_image,
+        },
+        currentParticipants,
+      );
 
-      if (user) {
-        await this.roomService.notifyUserJoined(
-          this.server,
-          dto.roomId,
-          {
-            userId,
-            nickname: user.nickname,
-            profile_image: user.profile_image,
-          },
-          currentParticipants,
-        );
-      }
-
-      logMessage(this.logger, LOG.ROOM.JOIN(userId, dto.roomId));
+      logMessage(this.logger, LOG.ROOM.JOIN(userId, dto.room_id));
     } catch (error) {
       // ValidationPipe 에러 처리
       if (error instanceof BadRequestException) {
@@ -180,20 +172,20 @@ export class RoomGateway {
       }
 
       // 참여 중인지 확인
-      const isInRoom = await this.roomService.isUserInRoom(userId, dto.roomId);
+      const isInRoom = await this.roomService.isUserInRoom(userId, dto.room_id);
       if (!isInRoom) {
-        logMessage(this.logger, LOG.ROOM.NOT_IN(userId, dto.roomId));
+        logMessage(this.logger, LOG.ROOM.NOT_IN(userId, dto.room_id));
         client.emit('error', { message: '해당 방에 참여하지 않았습니다.' });
         return;
       }
 
       // 공통 퇴장 처리
-      await this.leaveRoomProcess(client, userId, dto.roomId);
+      await this.leaveRoomProcess(client, userId, dto.room_id);
 
       // 클라이언트에 퇴장 성공 알림 (ACK)
-      client.emit('room:left', { roomId: dto.roomId });
+      client.emit('room:left', { room_id: dto.room_id });
 
-      logMessage(this.logger, LOG.ROOM.LEAVE(userId, dto.roomId));
+      logMessage(this.logger, LOG.ROOM.LEAVE(userId, dto.room_id));
     } catch (error) {
       // ValidationPipe 에러 처리
       if (error instanceof BadRequestException) {

--- a/be/src/modules/room/room.module.ts
+++ b/be/src/modules/room/room.module.ts
@@ -7,7 +7,7 @@ import { RoomService } from './room.service';
 import { RoomGateway } from './room.gateway';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([User])],
+  imports: [AuthModule, TypeOrmModule.forFeature([User])], // RoomService에서 UserRepository 사용하므로 유지
   controllers: [RoomController],
   providers: [RoomService, RoomGateway],
   exports: [RoomService],

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -17,8 +17,8 @@ import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { UUID } from 'crypto';
-import { createHash } from 'crypto';
 import { User } from '@src/modules/user/user.entity';
+import { toUuid } from '@src/common/utils/user-id';
 import { RoomRequestDto, RoomResponseDto, RoomDeleteResponseDto } from './dto/room.dto';
 import { ROOM_TYPE, RoomType } from './room.type';
 import { Server } from 'socket.io';
@@ -98,21 +98,9 @@ export class RoomService implements OnModuleInit {
     return true;
   }
 
-  /**
-   * 문자열을 UUID 형식으로 변환
-   * 'J001' 같은 문자열을 일관된 UUID 문자열로 변환
-   * 시드 스크립트와 동일한 변환 로직 사용
-   */
-  private stringToUuid(str: string): string {
-    const hash = createHash('md5').update(str).digest('hex');
-    const uuid = `${hash.substring(0, 8)}-${hash.substring(8, 12)}-${hash.substring(12, 16)}-${hash.substring(16, 20)}-${hash.substring(20, 32)}`;
-    return uuid;
-  }
-
   // 사용자 방 참여 처리
   async joinRoom(userId: string, roomId: string): Promise<void> {
-    // Mock ID('J001' 형식)를 UUID로 변환
-    const uuid = this.stringToUuid(userId);
+    const uuid = toUuid(userId);
 
     // MySQL에서 사용자 정보 조회 (Single Source of Truth)
     const user = await this.userRepository.findOne({
@@ -124,11 +112,11 @@ export class RoomService implements OnModuleInit {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    // room:{roomId}:members Hash에 userId 추가 (참여 시간)
-    await this.redisClient.hSet(`room:${roomId}:members`, userId, Date.now().toString());
+    // room:{roomId}:members Hash에 UUID 추가 (참여 시간)
+    await this.redisClient.hSet(`room:${roomId}:members`, uuid, Date.now().toString());
 
-    // room:{roomId}:members:{userId} Hash에 멤버 상세 정보 저장
-    await this.redisClient.hSet(`room:${roomId}:members:${userId}`, {
+    // room:{roomId}:members:{uuid} Hash에 멤버 상세 정보 저장
+    await this.redisClient.hSet(`room:${roomId}:members:${uuid}`, {
       nickname: user.nickname,
       profile_image: user.profile_image || '',
       role: user.role || 'USER',
@@ -138,8 +126,8 @@ export class RoomService implements OnModuleInit {
       join_date: new Date().toISOString(),
     });
 
-    // user:{userId}:rooms Set에 방 ID 추가
-    await this.redisClient.sAdd(`user:${userId}:rooms`, roomId);
+    // user:{uuid}:rooms Set에 방 ID 추가
+    await this.redisClient.sAdd(`user:${uuid}:rooms`, roomId);
 
     // 참여자 수 증가
     await this.increaseCurrentParticipants(roomId);
@@ -148,9 +136,11 @@ export class RoomService implements OnModuleInit {
 
   // 사용자 방 제거 처리
   async leaveRoom(userId: string, roomId: string): Promise<void> {
+    const uuid = toUuid(userId);
+
     // 방 멤버 목록에서 제거 (Hash), 사용자의 참여 방 목록에서 제거 (Set)
-    await this.redisClient.hDel(`room:${roomId}:members`, userId);
-    await this.redisClient.sRem(`user:${userId}:rooms`, roomId);
+    await this.redisClient.hDel(`room:${roomId}:members`, uuid);
+    await this.redisClient.sRem(`user:${uuid}:rooms`, roomId);
 
     // 참여자 수 감소
     await this.decreaseCurrentParticipants(roomId);
@@ -159,13 +149,15 @@ export class RoomService implements OnModuleInit {
 
   // 사용자 특정 방 참여 여부 확인
   async isUserInRoom(userId: string, roomId: string): Promise<boolean> {
-    const exists = await this.redisClient.hExists(`room:${roomId}:members`, userId);
+    const uuid = toUuid(userId);
+    const exists = await this.redisClient.hExists(`room:${roomId}:members`, uuid);
     return Boolean(exists);
   }
 
   // 사용자 참여 중인 모든 방 목록 조회 (글로벌 포함)
   async getUserRooms(userId: string): Promise<string[]> {
-    const rooms = await this.redisClient.sMembers(`user:${userId}:rooms`);
+    const uuid = toUuid(userId);
+    const rooms = await this.redisClient.sMembers(`user:${uuid}:rooms`);
     return rooms;
   }
 
@@ -212,7 +204,8 @@ export class RoomService implements OnModuleInit {
 
   // 사용자 연결 해제 시 모든 방에서 제거
   async leaveAllRooms(userId: string): Promise<void> {
-    const rooms = await this.getUserRooms(userId);
+    const uuid = toUuid(userId);
+    const rooms = await this.redisClient.sMembers(`user:${uuid}:rooms`);
     for (const roomId of rooms) {
       await this.leaveRoom(userId, roomId);
     }
@@ -220,8 +213,9 @@ export class RoomService implements OnModuleInit {
 
   // 사용자 방 호스트 여부 확인
   async isHost(userId: string, roomId: string): Promise<boolean> {
+    const uuid = toUuid(userId);
     const host = await this.redisClient.hGet(`room:${roomId}`, 'host_id');
-    return host === userId;
+    return host === uuid;
   }
 
   /**
@@ -235,9 +229,11 @@ export class RoomService implements OnModuleInit {
 
     if (roomData.max_participants <= 1) throw new HttpException('최대 참여자 수는 2명 이상이어야 합니다.', 400);
 
+    const hostUuid = toUuid(hostId);
+
     await this.redisClient.hSet(`room:${id}`, {
       title: roomData.title,
-      host_id: hostId,
+      host_id: hostUuid,
       type: ROOM_TYPE.LOCAL,
       max_participants: roomData.max_participants.toString(),
       current_participants: '0',
@@ -272,11 +268,12 @@ export class RoomService implements OnModuleInit {
     const roomKey = `room:${roomId}`;
     const tagKey = `room:${roomId}:tags`;
 
+    const hostUuid = toUuid(hostId);
     const existingHostId = await this.redisClient.hGet(roomKey, 'host_id');
 
     if (!existingHostId) throw new HttpException('존재하지 않는 방입니다.', 404);
 
-    if (existingHostId !== hostId) throw new HttpException('방 수정 권한이 없습니다.', 403);
+    if (existingHostId !== hostUuid) throw new HttpException('방 수정 권한이 없습니다.', 403);
 
     if (roomData.max_participants <= 1) throw new HttpException('최대 참여자 수는 2명 이상이어야 합니다.', 400);
 
@@ -314,18 +311,19 @@ export class RoomService implements OnModuleInit {
     const memberKey = `room:${roomId}:members`;
     const tagKey = `room:${roomId}:tags`;
 
+    const hostUuid = toUuid(hostId);
     const [existingHostId, members] = await Promise.all([
       this.redisClient.hGet(roomKey, 'host_id'),
-      this.redisClient.hKeys(memberKey), // 멤버 ID 목록 가져오기
+      this.redisClient.hKeys(memberKey), // 멤버 ID 목록 가져오기 (이미 UUID 형식)
     ]);
 
     if (!existingHostId) throw new HttpException('존재하지 않는 방입니다.', 404);
 
-    if (existingHostId !== hostId) throw new HttpException('방 삭제 권한이 없습니다.', 403);
+    if (existingHostId !== hostUuid) throw new HttpException('방 삭제 권한이 없습니다.', 403);
 
-    // 방 정보 및 멤버 목록 삭제
+    // 방 정보 및 멤버 목록 삭제 (members는 이미 UUID 형식)
     await Promise.all([
-      ...members.map((userId) => this.redisClient.sRem(`user:${userId}:rooms`, roomId)),
+      ...members.map((uuid) => this.redisClient.sRem(`user:${uuid}:rooms`, roomId)),
       this.redisClient.del(roomKey),
       this.redisClient.del(memberKey),
       this.redisClient.del(tagKey),

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -600,4 +600,26 @@ export class RoomService implements OnModuleInit {
     server.emit('chat:global:participants-updated', data);
     logMessage(this.logger, LOG.CHAT.PARTICIPANTS_UPDATED(roomId, currentParticipants));
   }
+
+  // 글로벌 채팅 최신 메시지 조회 (최대 30개)
+  async getGlobalChatRecents(roomId: string): Promise<
+    Array<{
+      sender_id: string;
+      content: string;
+      nickname: string;
+      profile_image: string;
+      create_date: string;
+    }>
+  > {
+    try {
+      const recentsKey = `room:${roomId}:recents`;
+      const messages = await this.redisClient.lRange(recentsKey, 0, -1);
+
+      return messages.map((msg) => JSON.parse(msg));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`글로벌 채팅 최신 메시지 조회 실패: ${errorMessage}`);
+      return [];
+    }
+  }
 }

--- a/be/src/providers/redis/redis-io.adapter.ts
+++ b/be/src/providers/redis/redis-io.adapter.ts
@@ -4,6 +4,7 @@ import { createAdapter } from '@socket.io/redis-adapter';
 import { RedisClientType } from 'redis';
 import type { ExtendedError } from 'socket.io/dist/namespace';
 import { MockAuthService } from '@src/modules/auth/mock-auth.service';
+import { toUuid } from '@src/common/utils/user-id';
 
 export class RedisIoAdapter extends IoAdapter {
   private adapterConstructor: ReturnType<typeof createAdapter>;
@@ -59,7 +60,8 @@ export class RedisIoAdapter extends IoAdapter {
         return next();
       }
 
-      await this.handleAuthenticatedSession(server, socket, authResult.userId);
+      // UUID 형식의 userId와 원본 ID를 모두 저장 (로그용)
+      await this.handleAuthenticatedSession(server, socket, authResult.userId, authResult.originalUserId);
       next();
     });
 
@@ -70,10 +72,15 @@ export class RedisIoAdapter extends IoAdapter {
    * 소켓 인증 처리
    *
    * TODO: Mock 토큰 검증 로직을 JWT 토큰 검증으로 교체
+   *
+   * 반환값: 원본 ID('J001')를 UUID로 변환하여 반환
+   * - MySQL과 Redis 모두 UUID 형식 사용
+   * - 로그에는 원본 ID 표시 (별도 처리)
    */
   private authenticateSocket(socket: Socket): {
     userId: string | null;
     isAuthenticated: boolean;
+    originalUserId?: string; // 로그용 원본 ID
   } {
     // TODO: query.userId 방식 제거 (개발 편의용)
     const queryUserId = socket.handshake.query.userId as string;
@@ -99,13 +106,23 @@ export class RedisIoAdapter extends IoAdapter {
     // TODO: Mock 토큰 검증을 JWT 토큰 검증으로 교체
     if (token && !queryUserId) {
       const payload = this.mockAuthService.verifyMockToken(token);
-      if (payload) return { userId: payload.userId, isAuthenticated: true };
+      if (payload) {
+        // 원본 ID를 UUID로 변환
+        const originalUserId = payload.userId;
+        const uuid = toUuid(originalUserId);
+        return { userId: uuid, isAuthenticated: true, originalUserId };
+      }
     }
 
     // TODO: query.userId 방식 제거 (개발 편의용)
     if (queryUserId) {
       const user = this.mockAuthService.getMockUserById(queryUserId);
-      if (user) return { userId: queryUserId, isAuthenticated: true };
+      if (user) {
+        // 원본 ID를 UUID로 변환
+        const originalUserId = queryUserId;
+        const uuid = toUuid(originalUserId);
+        return { userId: uuid, isAuthenticated: true, originalUserId };
+      }
     }
 
     return {
@@ -116,8 +133,15 @@ export class RedisIoAdapter extends IoAdapter {
 
   /**
    * 인증된 사용자의 세션 관리
+   * @param userId UUID 형식의 사용자 ID (MySQL/Redis에서 사용)
+   * @param originalUserId 원본 ID('J001' 형식, 로그용)
    */
-  private async handleAuthenticatedSession(server: any, socket: Socket, userId: string): Promise<void> {
+  private async handleAuthenticatedSession(
+    server: any,
+    socket: Socket,
+    userId: string,
+    originalUserId?: string,
+  ): Promise<void> {
     const sessionKey = `user:session:${userId}`;
     const existingSocketId = await this.pubClient.get(sessionKey);
 
@@ -127,12 +151,16 @@ export class RedisIoAdapter extends IoAdapter {
       if (existingSocket) existingSocket.disconnect(true);
     }
 
-    // 세션 저장 (24시간 유지)
+    // 세션 저장 (24시간 유지) - UUID 형식 사용
     await this.pubClient.set(sessionKey, socket.id, { EX: 86400 });
 
-    // socket.data에 userId 저장 (권한 검증용)
+    // socket.data에 UUID 형식의 userId 저장 (권한 검증용)
     socket.data.userId = userId;
     socket.data.authenticated = true;
+    // 로그용 원본 ID도 저장 (선택사항)
+    if (originalUserId) {
+      socket.data.originalUserId = originalUserId;
+    }
 
     // disconnect 핸들러 설정
     this.setupDisconnectHandler(socket, sessionKey);

--- a/be/src/providers/redis/redis-io.adapter.ts
+++ b/be/src/providers/redis/redis-io.adapter.ts
@@ -115,6 +115,8 @@ export class RedisIoAdapter extends IoAdapter {
     }
 
     // TODO: query.userId 방식 제거 (개발 편의용)
+    // OAuth 환경에서는 이 부분이 제거되고, 토큰 방식만 사용됩니다.
+    // 개발 편의를 위해 Mock 사용자 목록에서 확인 (MySQL 조회 불필요)
     if (queryUserId) {
       const user = this.mockAuthService.getMockUserById(queryUserId);
       if (user) {

--- a/be/src/scripts/seed-rooms.ts
+++ b/be/src/scripts/seed-rooms.ts
@@ -14,6 +14,7 @@
 import { createClient, RedisClientType } from 'redis';
 import { loadEnv } from '../config/env';
 import { ROOM_TYPE } from '../modules/room/room.type';
+import { toUuid } from '@src/common/utils/user-id';
 
 loadEnv();
 
@@ -226,7 +227,28 @@ async function seedRooms() {
   try {
     await client.connect();
 
-    console.log('\n=== 방 더미 데이터 생성 시작 ===\n');
+    // 기존 사용자별 방 목록 키 정리 (J001 형식으로 저장된 오래된 데이터)
+    console.log('\n=== 기존 사용자별 방 목록 키 정리 ===');
+    const userKeys = await client.keys('user:*:rooms');
+    const oldFormatKeys = userKeys.filter((key) => {
+      // J001, J002 같은 형식의 키만 필터링 (UUID 형식이 아닌 것)
+      const match = key.match(/^user:(.+):rooms$/);
+      if (!match) return false;
+      const userId = match[1];
+      // UUID 형식이 아니면 (하이픈이 없거나 J로 시작하면) 오래된 형식
+      return !userId.includes('-') || userId.startsWith('J');
+    });
+
+    if (oldFormatKeys.length > 0) {
+      console.log(`⚠️  오래된 형식의 사용자 키 ${oldFormatKeys.length}개 발견: ${oldFormatKeys.join(', ')}`);
+      console.log('오래된 형식의 키를 삭제합니다...');
+      await Promise.all(oldFormatKeys.map((key) => client.del(key)));
+      console.log(`✅ ${oldFormatKeys.length}개의 오래된 키 삭제 완료\n`);
+    } else {
+      console.log('✅ 오래된 형식의 키가 없습니다.\n');
+    }
+
+    console.log('=== 방 더미 데이터 생성 시작 ===\n');
 
     for (const room of dummyRooms) {
       const roomKey = `room:${room.id}`;
@@ -239,10 +261,13 @@ async function seedRooms() {
         console.log(`✅ 기존 방 삭제 완료: ${room.title} (${room.id})\n`);
       }
 
+      // hostId를 UUID로 변환
+      const hostUuid = toUuid(room.hostId);
+
       // 방 메타데이터 저장
       await client.hSet(roomKey, {
         title: room.title,
-        host_id: room.hostId,
+        host_id: hostUuid,
         type: room.type,
         max_participants: room.maxParticipants.toString(),
         current_participants: room.members.length.toString(),
@@ -259,11 +284,14 @@ async function seedRooms() {
 
       // 멤버 정보 저장
       for (const member of room.members) {
-        // room:{roomId}:members Hash에 userId 추가 (참여 시간)
-        await client.hSet(`room:${room.id}:members`, member.userId, Date.now().toString());
+        // Mock ID('J001' 형식)를 UUID로 변환
+        const memberUuid = toUuid(member.userId);
 
-        // room:{roomId}:members:{userId} Hash에 멤버 상세 정보 저장
-        await client.hSet(`room:${room.id}:members:${member.userId}`, {
+        // room:{roomId}:members Hash에 UUID 추가 (참여 시간)
+        await client.hSet(`room:${room.id}:members`, memberUuid, Date.now().toString());
+
+        // room:{roomId}:members:{uuid} Hash에 멤버 상세 정보 저장
+        await client.hSet(`room:${room.id}:members:${memberUuid}`, {
           nickname: member.nickname,
           profile_image: member.profileImage,
           role: 'USER',
@@ -273,8 +301,8 @@ async function seedRooms() {
           join_date: new Date().toISOString(),
         });
 
-        // user:{userId}:rooms Set에 방 ID 추가
-        await client.sAdd(`user:${member.userId}:rooms`, room.id);
+        // user:{uuid}:rooms Set에 방 ID 추가
+        await client.sAdd(`user:${memberUuid}:rooms`, room.id);
       }
 
       console.log(`✅ 방 생성 완료: ${room.title} (${room.id})`);

--- a/be/src/scripts/seed-users.ts
+++ b/be/src/scripts/seed-users.ts
@@ -2,20 +2,22 @@ import { DataSource } from 'typeorm';
 import { User } from '@src/modules/user/user.entity';
 import databaseConfig from '@src/providers/database/database.config';
 import mockUsers from '@src/mocks/users.js';
-import { createHash } from 'crypto';
+import { toUuid } from '@src/common/utils/user-id';
 
-/**
- * 문자열을 UUID 형식으로 변환
- * 'J001' 같은 문자열을 일관된 UUID 문자열로 변환
- * UUID transformer는 하이픈이 없는 hex 문자열을 받아서 BINARY(16)으로 변환
- */
-function stringToUuid(str: string): string {
-  // 문자열을 MD5 해시하여 UUID 형식으로 변환
-  const hash = createHash('md5').update(str).digest('hex');
-  // UUID 형식으로 포맷팅 (8-4-4-4-12)
-  const uuid = `${hash.substring(0, 8)}-${hash.substring(8, 12)}-${hash.substring(12, 16)}-${hash.substring(16, 20)}-${hash.substring(20, 32)}`;
-  return uuid;
-}
+/*
+1. users.js 파일에서 사용자 데이터 읽기
+2. 각 사용자의 id ('J001' 등)를 UUID 형식으로 변환 (MD5 해시 사용)
+3. MySQL user 테이블에 데이터 삽입
+4. 주의사항:
+    - 기존 데이터가 있으면 자동으로 삭제 후 새로 삽입
+
+로컬 환경에서 실행
+- cd be
+- pnpm seed:users
+
+도커 컨테이너 내부에서 실행
+- docker exec eryuk-server pnpm seed:users:docker
+*/
 
 /**
  * 사용자 데이터 시드 스크립트
@@ -44,7 +46,7 @@ async function seedUsers() {
     // 사용자 데이터 변환 및 삽입
     const usersToInsert = mockUsers.map((mockUser) => {
       const user = new User();
-      user.id = stringToUuid(mockUser.id);
+      user.id = toUuid(mockUser.id);
       user.email = mockUser.email;
       user.nickname = mockUser.nickname;
       user.profile_image = mockUser.profile_image;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

- mock 데이터를 기반으로 room 데이터 저장 및 스크립트 작성 (Redis)
- mock 데이터를 기반으로 user 데이터 저장 및 스크립트 작성 (MySQL)
- 방 참여 시 mysql 조회하여 유저 정보 가져오도록 수정
- userId를 UUID 형식으로 통일 -> MySQL, Redis
- mock 데이터 조회 부분을 mysql 조회로 전면 수정
- MVC 구조에 맞게 비즈니스 로직 분리
- 로컬 방 채팅 구현
  - 응답 서식을 API에 맞게 수정
- 글로벌 채팅 입장 시 이전 30개 채팅 기록 보여주기

---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- close #135 
- close #111 
- close #137 

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [userId UUID 통일 + 사용자 정보 조회 MockData(X) MySQL(O) ](https://rapid-bubble-113.notion.site/userId-UUID-MockData-X-MySQL-O-2e9207f2334180bc812feeb53b5f5bde?source=copy_link)

