### PR TITLE
feat: 유저 토큰 인증 및 userId 값 추출을 위한 guard 구현

### DIFF
--- a/be/src/modules/auth/auth.guard.ts
+++ b/be/src/modules/auth/auth.guard.ts
@@ -1,0 +1,38 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { MockAuthService } from './mock-auth.service';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly authService: MockAuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    return this.mockValidateRequest(request);
+  }
+
+  async mockValidateRequest(request: any): Promise<boolean> {
+    const authHeader = request.headers['authorization'];
+
+    if (!authHeader) throw new UnauthorizedException('인증이 필요합니다.');
+
+    const token = authHeader.replace('Bearer ', '');
+    const payload = this.authService.verifyMockToken(token);
+
+    if (!payload) throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+
+    request['user'] = { id: payload.userId };
+
+    return true;
+  }
+
+  validateRequest(request: any): boolean {
+    // 여기에 실제 인증 로직을 구현하세요.
+    // 예: 토큰 검증, 세션 확인 등
+    const authToken = request.headers['authorization'];
+    if (authToken && authToken === 'valid-token') {
+      return true;
+    }
+    return false;
+  }
+}

--- a/be/src/modules/auth/auth.module.ts
+++ b/be/src/modules/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
+import { AuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
 import { MockAuthService } from './mock-auth.service';
 import { User } from '../user/user.entity';
@@ -8,7 +9,7 @@ import { User } from '../user/user.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [AuthController],
-  providers: [AuthService, MockAuthService],
-  exports: [AuthService, MockAuthService],
+  providers: [AuthGuard, AuthService, MockAuthService],
+  exports: [AuthGuard, AuthService, MockAuthService],
 })
 export class AuthModule {}

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -2,18 +2,17 @@ import {
   Body,
   Controller,
   Delete,
-  Headers,
   Param,
   Get,
   Patch,
   Post,
   HttpException,
-  UnauthorizedException,
   HttpStatus,
   Query,
   Logger,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
-import { MockAuthService } from '@src/modules/auth/mock-auth.service';
 import {
   RoomRequestDto,
   RoomCreateResponseDto,
@@ -27,34 +26,22 @@ import {
 } from './dto/room.dto';
 import { RoomService } from './room.service';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
-import { LOG, logMessage } from '@src/common/utils/log-messages';
+import { AuthGuard } from '@src/modules/auth/auth.guard';
 
 @Controller('rooms')
 export class RoomController {
   private readonly logger = new Logger(RoomController.name);
 
-  constructor(
-    private readonly roomService: RoomService,
-    private readonly authService: MockAuthService,
-  ) {}
+  constructor(private readonly roomService: RoomService) {}
 
   /**
    * 대화방 생성
    */
   @Post()
+  @UseGuards(AuthGuard)
   @ApiResponseMessage('대화방이 성공적으로 생성되었습니다.')
-  async createRoom(
-    @Headers('authorization') authHeader: string,
-    @Body() dto: RoomRequestDto,
-  ): Promise<RoomCreateResponseDto> {
-    if (!authHeader) throw new UnauthorizedException('인증이 필요합니다.');
-
-    const token = authHeader.replace('Bearer ', '');
-    const payload = this.authService.verifyMockToken(token);
-
-    if (!payload) throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-
-    const userId = payload.userId;
+  async createRoom(@Req() req, @Body() dto: RoomRequestDto): Promise<RoomCreateResponseDto> {
+    const userId = req.user.id;
 
     return await this.roomService.createRoom(userId, dto);
   }
@@ -63,20 +50,14 @@ export class RoomController {
    * 대화방 수정
    */
   @Patch(':roomId')
+  @UseGuards(AuthGuard)
   @ApiResponseMessage('대화방이 성공적으로 수정되었습니다.')
   async updateRoom(
-    @Headers('authorization') authHeader: string,
+    @Req() req,
     @Param('roomId') roomId: string,
     @Body() dto: RoomRequestDto,
   ): Promise<RoomCreateResponseDto> {
-    if (!authHeader) throw new UnauthorizedException('인증이 필요합니다.');
-
-    const token = authHeader.replace('Bearer ', '');
-    const payload = this.authService.verifyMockToken(token);
-
-    if (!payload) throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-
-    const userId = payload.userId;
+    const userId = req.user.id;
 
     return await this.roomService.updateRoom(userId, roomId, dto);
   }
@@ -85,19 +66,10 @@ export class RoomController {
    * 대화방 삭제
    */
   @Delete(':roomId')
+  @UseGuards(AuthGuard)
   @ApiResponseMessage('대화방이 성공적으로 삭제되었습니다.')
-  async deleteRoom(
-    @Headers('authorization') authHeader: string,
-    @Param('roomId') roomId: string,
-  ): Promise<RoomDeleteResponseDto> {
-    if (!authHeader) throw new UnauthorizedException('인증이 필요합니다.');
-
-    const token = authHeader.replace('Bearer ', '');
-    const payload = this.authService.verifyMockToken(token);
-
-    if (!payload) throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-
-    const userId = payload.userId;
+  async deleteRoom(@Req() req, @Param('roomId') roomId: string): Promise<RoomDeleteResponseDto> {
+    const userId = req.user.id;
 
     return await this.roomService.deleteRoom(userId, roomId);
   }
@@ -134,19 +106,11 @@ export class RoomController {
    * 대화방 입장 정보 조회
    */
   @Get(':id/join')
+  @UseGuards(AuthGuard)
   @ApiResponseMessage('방 입장 정보 조회에 성공 했습니다.')
-  async getRoomJoinInfo(
-    @Headers('authorization') authHeader: string,
-    @Param('id') roomId: string,
-  ): Promise<RoomJoinInfoResponseDto> {
-    if (!authHeader) throw new UnauthorizedException('인증이 필요합니다.');
+  async getRoomJoinInfo(@Req() req, @Param('id') roomId: string): Promise<RoomJoinInfoResponseDto> {
+    const userId = req.user.id;
 
-    const token = authHeader.replace('Bearer ', '');
-    const payload = this.authService.verifyMockToken(token);
-
-    if (!payload) throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-
-    const userId = payload.userId;
     return await this.roomService.getRoomJoinInfo(userId, roomId);
   }
 
@@ -162,26 +126,12 @@ export class RoomController {
    * 방 입장 가능 여부 검증
    */
   @Post(':id/validate-join')
+  @UseGuards(AuthGuard)
   @ApiResponseMessage('입장 가능한 방입니다.')
-  async validateJoin(
-    @Param('id') roomId: string,
-    @Body() dto: JoinRoomRequestDto,
-    @Headers('authorization') authHeader?: string,
-  ): Promise<RoomJoinDto> {
-    if (!authHeader) {
-      logMessage(this.logger, LOG.ROOM.UNAUTH_API_ACCESS_JOIN(roomId));
-      throw new UnauthorizedException('인증이 필요합니다.');
-    }
+  async validateJoin(@Req() req, @Param('id') roomId: string, @Body() dto: JoinRoomRequestDto): Promise<RoomJoinDto> {
+    const userId = req.user.id;
 
-    const token = authHeader.replace('Bearer ', '');
-    const payload = this.authService.verifyMockToken(token);
-
-    if (!payload) {
-      logMessage(this.logger, LOG.ROOM.INVALID_TOKEN_API_JOIN(roomId));
-      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-    }
-
-    await this.roomService.validateJoinRoom(roomId, payload.userId, dto.password);
+    await this.roomService.validateJoinRoom(roomId, userId, dto.password);
 
     return { room_id: roomId };
   }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

가드 로직 추가

http 요청에 대해 인가처리를 해줌

정상작동 확인함

사용법

1. module 에 Auth module import
2. 인가 로직이 필요한 컨트롤러의 메소드에 @UseGuards(AuthGuard) 달기
3. 토큰으로 부터 추출한 userId 가 필요하다면 @Req req 를 인자로 받고 req.user.id 로 추출할 수 있음

```ts
  @Patch(':roomId')
  @UseGuards(AuthGuard)
  @ApiResponseMessage('대화방이 성공적으로 수정되었습니다.')
  async updateRoom(
    @Req() req,
    @Param('roomId') roomId: string,
    @Body() dto: RoomRequestDto,
  ): Promise<RoomCreateResponseDto> {
    const userId = req.user.id;

    return await this.roomService.updateRoom(userId, roomId, dto);
  }
```

