### PR TITLE
[Feat] 게임 참가, 나가기, 목록 조회 API 구현

### DIFF
--- a/be/package.json
+++ b/be/package.json
@@ -30,7 +30,9 @@
     "seed:rooms": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-rooms.ts",
     "seed:rooms:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-rooms.ts",
     "seed:users": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts",
-    "seed:users:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts"
+    "seed:users:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts",
+    "seed:games": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-games.ts",
+    "seed:games:docker": "DB_HOST=db DB_PORT=3306 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-games.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.20",

--- a/be/src/common/constants/constants.ts
+++ b/be/src/common/constants/constants.ts
@@ -1,2 +1,13 @@
 export const GLOBAL_ROOM_ID = 'global-room-001';
 export const USER_SESSION_EXPIRATION_TIME = 30;
+
+/**
+ * WebSocket 및 HTTP 에러 코드 상수
+ */
+export const ERROR_CODE = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  FORBIDDEN: 'FORBIDDEN',
+  NOT_FOUND: 'NOT_FOUND',
+  BAD_REQUEST: 'BAD_REQUEST',
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+} as const;

--- a/be/src/common/interceptors/transform.interceptor.ts
+++ b/be/src/common/interceptors/transform.interceptor.ts
@@ -43,15 +43,21 @@ export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> 
         };
       }),
       tap((responseData) => {
-        // data가 객체이고 rooms 배열이 비어있으면 204 No Content 설정
-        if (
-          responseData?.data &&
-          typeof responseData.data === 'object' &&
-          'rooms' in responseData.data &&
-          Array.isArray(responseData.data.rooms) &&
-          responseData.data.rooms.length === 0
-        ) {
-          response.status(HttpStatus.NO_CONTENT);
+        // data가 객체이고 rooms 또는 games 배열이 비어있으면 204 No Content 설정
+        if (responseData?.data && typeof responseData.data === 'object') {
+          const hasEmptyRooms =
+            'rooms' in responseData.data &&
+            Array.isArray(responseData.data.rooms) &&
+            responseData.data.rooms.length === 0;
+
+          const hasEmptyGames =
+            'games' in responseData.data &&
+            Array.isArray(responseData.data.games) &&
+            responseData.data.games.length === 0;
+
+          if (hasEmptyRooms || hasEmptyGames) {
+            response.status(HttpStatus.NO_CONTENT);
+          }
         }
       }),
     );

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -279,6 +279,10 @@ export const LOG = {
       message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
       level: 'error',
     }),
+    LEAVE: (roomId: string, userId: string): LogMessage => ({
+      message: `게임 참가 취소: roomId=${roomId}, userId=${userId}`,
+      level: 'log',
+    }),
   },
 } as const;
 

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -271,6 +271,14 @@ export const LOG = {
       message: `게임 모집 시작: roomId=${roomId}, userId=${userId}`,
       level: 'log',
     }),
+    JOIN_REQUEST: (roomId: string, userId: string): LogMessage => ({
+      message: `게임 참가 요청: roomId=${roomId}, userId=${userId}`,
+      level: 'debug',
+    }),
+    GAME_STATE_FETCH_ERROR: (roomId: string, error: string): LogMessage => ({
+      message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
+      level: 'error',
+    }),
   },
 } as const;
 

--- a/be/src/common/utils/ws-error-code.ts
+++ b/be/src/common/utils/ws-error-code.ts
@@ -1,9 +1,10 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { ERROR_CODE } from '@src/common/constants/constants';
 
 /**
  * WebSocket 에러 코드 타입
  */
-export type WsErrorCode = 'UNAUTHORIZED' | 'FORBIDDEN' | 'NOT_FOUND' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
+export type WsErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
 
 /**
  * WebSocket 에러 응답 인터페이스
@@ -36,19 +37,19 @@ export function createWsErrorResponse(exception: unknown, defaultMessage?: strin
     let code: WsErrorCode;
     switch (status) {
       case HttpStatus.UNAUTHORIZED:
-        code = 'UNAUTHORIZED';
+        code = ERROR_CODE.UNAUTHORIZED;
         break;
       case HttpStatus.FORBIDDEN:
-        code = 'FORBIDDEN';
+        code = ERROR_CODE.FORBIDDEN;
         break;
       case HttpStatus.NOT_FOUND:
-        code = 'NOT_FOUND';
+        code = ERROR_CODE.NOT_FOUND;
         break;
       case HttpStatus.BAD_REQUEST:
-        code = 'BAD_REQUEST';
+        code = ERROR_CODE.BAD_REQUEST;
         break;
       default:
-        code = 'INTERNAL_SERVER_ERROR';
+        code = ERROR_CODE.INTERNAL_SERVER_ERROR;
     }
 
     return { code, message };
@@ -56,13 +57,13 @@ export function createWsErrorResponse(exception: unknown, defaultMessage?: strin
 
   if (exception instanceof Error) {
     return {
-      code: 'INTERNAL_SERVER_ERROR',
+      code: ERROR_CODE.INTERNAL_SERVER_ERROR,
       message: exception.message || defaultMessage || '서버 오류가 발생했습니다.',
     };
   }
 
   return {
-    code: 'INTERNAL_SERVER_ERROR',
+    code: ERROR_CODE.INTERNAL_SERVER_ERROR,
     message: defaultMessage || '서버 오류가 발생했습니다.',
   };
 }

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -13,3 +13,16 @@ export class GameJoinDto {
   @IsUUID()
   room_id: string;
 }
+
+export interface GameInfoDto {
+  id: string;
+  title: string;
+  type: string;
+  description: string;
+  min_participants: number;
+  max_participants: number;
+}
+
+export class GameListResponseDto {
+  games: GameInfoDto[];
+}

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -6,3 +6,10 @@ export class GameRecruitDto {
   @IsUUID()
   room_id: string;
 }
+
+export class GameJoinDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  room_id: string;
+}

--- a/be/src/modules/game/game.controller.ts
+++ b/be/src/modules/game/game.controller.ts
@@ -1,4 +1,25 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { GameService } from './game.service';
+import { GameListResponseDto } from './dto/game.dto';
+import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
 
-@Controller('game')
-export class GameController {}
+@Controller('games')
+export class GameController {
+  private readonly logger = new Logger(GameController.name);
+
+  constructor(private readonly gameService: GameService) {}
+
+  /**
+   * 게임 목록 조회 -> GET /api/games/all
+   */
+  @Get('all')
+  @ApiResponseMessage('게임 목록을 성공적으로 조회했습니다.')
+  async getAllGames(): Promise<GameListResponseDto> {
+    try {
+      return await this.gameService.getAllGames();
+    } catch (error) {
+      this.logger.error('게임 목록 조회 실패', error.stack);
+      throw new HttpException('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -1,11 +1,12 @@
 import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger, BadRequestException, UseFilters, UsePipes } from '@nestjs/common';
+import { Logger, UseFilters, UsePipes } from '@nestjs/common';
 import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
-import { GameRecruitDto } from './dto/game-recruit.dto';
+import { GameRecruitDto } from './dto/game.dto';
+import { GameJoinDto } from './dto/game.dto';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
 
 @UseFilters(new WsExceptionFilter())
@@ -55,6 +56,34 @@ export class GameGateway {
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorResponse = createWsErrorResponse(error, '게임 모집 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
+   * 게임 참가
+   */
+  @SubscribeMessage('game:join')
+  async handleGameJoin(@ConnectedSocket() client: Socket, @MessageBody() dto: GameJoinDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      const payload = await this.gameService.joinGame(this.server, dto.room_id, userId);
+
+      client.emit('game:join', payload);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
       try {
         client.emit('error', errorResponse);
         return;

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -92,4 +92,40 @@ export class GameGateway {
       }
     }
   }
+
+  /**
+   * 게임 나가기
+   */
+  @SubscribeMessage('game:leave')
+  async handleGameLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: GameJoinDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      // 게임 참가 취소 처리
+      await this.gameService.leaveGame(dto.room_id, userId);
+
+      // 남은 참여자 수 계산
+      const participantCount = await this.gameService.getParticipantCount(dto.room_id);
+
+      // 브로드캐스트
+      this.server.to(dto.room_id).emit('game:leave', {
+        left_user_id: userId,
+        participant_count: participantCount,
+      });
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 나가기 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
 }

--- a/be/src/modules/game/game.module.ts
+++ b/be/src/modules/game/game.module.ts
@@ -2,11 +2,13 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { GameService } from './game.service';
 import { GameGateway } from './game.gateway';
+import { GameController } from './game.controller';
 import { RoomModule } from '@src/modules/room/room.module';
 import { Game } from './game.entity';
 
 @Module({
   imports: [forwardRef(() => RoomModule), TypeOrmModule.forFeature([Game])],
+  controllers: [GameController],
   providers: [GameService, GameGateway],
   exports: [GameService],
 })

--- a/be/src/modules/game/game.module.ts
+++ b/be/src/modules/game/game.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { GameService } from './game.service';
 import { GameGateway } from './game.gateway';
 import { RoomModule } from '@src/modules/room/room.module';
+import { Game } from './game.entity';
 
 @Module({
-  imports: [RoomModule],
+  imports: [RoomModule, TypeOrmModule.forFeature([Game])],
   providers: [GameService, GameGateway],
   exports: [GameService],
 })

--- a/be/src/modules/game/game.module.ts
+++ b/be/src/modules/game/game.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { GameService } from './game.service';
 import { GameGateway } from './game.gateway';
@@ -6,7 +6,7 @@ import { RoomModule } from '@src/modules/room/room.module';
 import { Game } from './game.entity';
 
 @Module({
-  imports: [RoomModule, TypeOrmModule.forFeature([Game])],
+  imports: [forwardRef(() => RoomModule), TypeOrmModule.forFeature([Game])],
   providers: [GameService, GameGateway],
   exports: [GameService],
 })

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -287,16 +287,23 @@ export class GameService {
     });
   }
 
+  async getParticipantCount(roomId: string): Promise<number> {
+    const pattern = `room:${roomId}:game:players:*`;
+    const keys = await this.redisClient.keys(pattern);
+    return keys.length;
+  }
+
   /**
    * 게임 참가 취소
    */
   async leaveGame(roomId: string, userId: string): Promise<void> {
-    const playerKey = this.getParticipantKey(roomId, userId);
+    const uuid = toUuid(userId);
+    const playerKey = this.getParticipantKey(roomId, uuid);
     const exists = await this.redisClient.exists(playerKey);
 
     if (exists) {
       await this.redisClient.del(playerKey);
-      logMessage(this.logger, LOG.GAME.LEAVE(roomId, userId));
+      logMessage(this.logger, LOG.GAME.LEAVE(roomId, uuid));
     }
   }
 }

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, ForbiddenException, Inject } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ForbiddenException, Inject, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Server } from 'socket.io';
@@ -40,7 +40,7 @@ export class GameService {
   private readonly logger = new Logger(GameService.name);
 
   constructor(
-    private readonly roomService: RoomService,
+    @Inject(forwardRef(() => RoomService)) private readonly roomService: RoomService,
     @InjectRepository(Game) private readonly gameRepository: Repository<Game>,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
   ) {}
@@ -282,5 +282,18 @@ export class GameService {
       },
       participant_count: participantCount.toString(),
     });
+  }
+
+  /**
+   * 게임 참가 취소
+   */
+  async leaveGame(roomId: string, userId: string): Promise<void> {
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const exists = await this.redisClient.exists(playerKey);
+
+    if (exists) {
+      await this.redisClient.del(playerKey);
+      logMessage(this.logger, LOG.GAME.LEAVE(roomId, userId));
+    }
   }
 }

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -1,13 +1,49 @@
-import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ForbiddenException, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Server } from 'socket.io';
+import { RedisClientType } from 'redis';
 import { RoomService } from '@src/modules/room/room.service';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
+import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
+import { toUuid } from '@src/common/utils/user-id';
+import { Game } from './game.entity';
+
+interface GameParticipant {
+  user_id: string;
+  nickname: string;
+  profile_image: string;
+  is_ready: boolean;
+  score?: string;
+  rank?: string;
+}
+
+interface GameInfoPayload {
+  id: string;
+  title: string;
+  description?: string;
+  type: string;
+  min_participants: string;
+  max_participants: string;
+}
+
+interface GameJoinAckPayload {
+  current_players: string;
+  max_players: string;
+  host: { nickname: string; profile_image: string };
+  players: Array<{ nickname: string; profile_image: string; is_ready: boolean }>;
+  game?: GameInfoPayload;
+}
 
 @Injectable()
 export class GameService {
   private readonly logger = new Logger(GameService.name);
 
-  constructor(private readonly roomService: RoomService) {}
+  constructor(
+    private readonly roomService: RoomService,
+    @InjectRepository(Game) private readonly gameRepository: Repository<Game>,
+    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
+  ) {}
 
   /**
    * 게임 모집 시작
@@ -40,5 +76,211 @@ export class GameService {
     });
 
     logMessage(this.logger, LOG.GAME.RECRUIT_STARTED(roomId, userId));
+  }
+
+  /**
+   * 게임 참가 처리 및 상태 반환
+   */
+  async joinGame(server: Server, roomId: string, userId: string): Promise<GameJoinAckPayload> {
+    const uuid = toUuid(userId);
+
+    logMessage(this.logger, LOG.GAME.JOIN_REQUEST(roomId, uuid));
+
+    // 방 존재 여부
+    const isRoomExists = await this.roomService.roomExists(roomId);
+    if (!isRoomExists) {
+      throw new NotFoundException('존재하지 않는 방입니다.');
+    }
+    // 사용자가 그 방 멤버인지 확인
+    const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
+    if (!isInRoom) {
+      throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+    }
+
+    // 게임 참가자 명단에 추가
+    const wasAdded = await this.addParticipant(roomId, uuid);
+
+    const [roomInfo, participants, selectedGame] = await Promise.all([
+      this.roomService.getRoom(roomId),
+      this.getGameParticipants(roomId),
+      this.getSelectedGame(roomId),
+    ]);
+
+    // TODO: 방장이 게임 모집할 때 방장도 참가자 명단에 추가해줘야함!
+    const currentPlayers = participants.length;
+
+    const hostProfile = this.extractHostProfile(roomInfo.host_id, participants, roomInfo.participants);
+
+    const ackPayload: GameJoinAckPayload = {
+      current_players: currentPlayers.toString(),
+      max_players: roomInfo.current_participants.toString(),
+      host: hostProfile,
+      players: participants.map((participant) => ({
+        nickname: participant.nickname,
+        profile_image: participant.profile_image,
+        is_ready: participant.is_ready,
+      })),
+    };
+
+    if (selectedGame) {
+      ackPayload.game = selectedGame;
+    }
+
+    // 새로 추가된 경우에만 브로드캐스트
+    if (wasAdded) {
+      await this.broadcastGameJoin(server, roomId, uuid, currentPlayers, participants);
+    }
+
+    return ackPayload;
+  }
+
+  private getParticipantKey(roomId: string, userId: string): string {
+    return `room:${roomId}:game:players:${userId}`;
+  }
+
+  private async addParticipant(roomId: string, userId: string): Promise<boolean> {
+    // 기존에 이미 추가된 참가자인지 확인
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const exists = await this.redisClient.exists(playerKey);
+
+    if (!exists) {
+      // 방 멤버 정보에서 닉네임, 프로필 이미지 가져오기
+      const memberData = await this.redisClient.hGetAll(`room:${roomId}:members:${userId}`);
+
+      await this.redisClient.hSet(playerKey, {
+        nickname: memberData.nickname || '',
+        profile_image: memberData.profile_image || '',
+        is_ready: '0',
+        score: '0',
+        rank: '0',
+      });
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private async getGameParticipants(roomId: string): Promise<GameParticipant[]> {
+    const pattern = `room:${roomId}:game:players:*`;
+    const keys = await this.redisClient.keys(pattern);
+
+    if (!keys.length) return [];
+
+    const participants: GameParticipant[] = [];
+
+    for (const key of keys) {
+      const userId = key.replace(`room:${roomId}:game:players:`, '');
+      const playerData = await this.redisClient.hGetAll(key);
+
+      participants.push({
+        user_id: userId,
+        nickname: playerData.nickname || '',
+        profile_image: playerData.profile_image || '',
+        is_ready: playerData.is_ready === '1',
+        score: playerData.score,
+        rank: playerData.rank,
+      });
+    }
+
+    return participants;
+  }
+
+  private extractHostProfile(
+    hostId: string,
+    participants: GameParticipant[],
+    roomParticipants?: Array<{ user_id: string; nickname: string; profile_image: string }>,
+  ): { nickname: string; profile_image: string } {
+    const host =
+      participants.find((participant) => participant.user_id === hostId) ||
+      roomParticipants?.find((participant) => participant.user_id === hostId);
+
+    return {
+      nickname: host?.nickname || '',
+      profile_image: host?.profile_image || '',
+    };
+  }
+
+  private getGameKey(roomId: string): string {
+    return `room:${roomId}:game`;
+  }
+
+  private async getSelectedGame(roomId: string): Promise<GameInfoPayload | undefined> {
+    try {
+      const gameKey = this.getGameKey(roomId);
+      // 우선 Redis에서 조회
+      const gameData = await this.redisClient.hGetAll(gameKey);
+      if (!gameData || Object.keys(gameData).length === 0) return undefined;
+
+      // Redis에 id가 없다면 선택된 게임이 없는 것으로 간주 -> undefined
+      if (!gameData.id) return undefined;
+
+      // 선택된 게임의 모든 필드가 존재하는지 확인
+      const hasAllFields =
+        Boolean(gameData.title) &&
+        Boolean(gameData.type) &&
+        Boolean(gameData.min_participants) &&
+        Boolean(gameData.max_participants);
+
+      // 모든 필드가 존재하면 선택된 게임 정보 반환
+      if (hasAllFields) {
+        return {
+          id: gameData.id,
+          title: gameData.title,
+          description: gameData.description,
+          type: gameData.type,
+          min_participants: gameData.min_participants,
+          max_participants: gameData.max_participants,
+        };
+      }
+
+      // 캐시 불완전 시 MySQL에서 보강 후 Redis에 다시 저장
+      const dbGame = await this.gameRepository.findOne({ where: { id: gameData.id } });
+      if (!dbGame) return undefined;
+
+      // MySQL에서 조회한 게임 정보를 Redis에 저장
+      await this.redisClient.hSet(gameKey, {
+        id: dbGame.id,
+        title: dbGame.title,
+        description: dbGame.description || '',
+        type: dbGame.type,
+        min_participants: dbGame.min_participants?.toString() || '',
+        max_participants: dbGame.max_participants?.toString() || '',
+      });
+
+      return {
+        id: dbGame.id,
+        title: dbGame.title,
+        description: dbGame.description || '',
+        type: dbGame.type,
+        min_participants: dbGame.min_participants?.toString() || '',
+        max_participants: dbGame.max_participants?.toString() || '',
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logMessage(this.logger, LOG.GAME.GAME_STATE_FETCH_ERROR(roomId, errorMessage));
+      return undefined;
+    }
+  }
+
+  private async broadcastGameJoin(
+    server: Server,
+    roomId: string,
+    userId: string,
+    participantCount: number,
+    participants: GameParticipant[],
+  ): Promise<void> {
+    const joinedParticipant = participants.find((participant) => participant.user_id === userId);
+
+    // 방의 다른 모든 사람에게 브로드캐스트 (본인 제외하지 않음, 전체 브로드캐스트)
+    server.to(roomId).emit('game:joined', {
+      participant: {
+        user_id: joinedParticipant?.user_id || userId,
+        nickname: joinedParticipant?.nickname || '',
+        profile_image: joinedParticipant?.profile_image || '',
+        is_ready: joinedParticipant?.is_ready ?? false,
+      },
+      participant_count: participantCount.toString(),
+    });
   }
 }

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -70,6 +70,9 @@ export class GameService {
       throw new ForbiddenException('방장만 게임 모집을 시작할 수 있습니다.');
     }
 
+    // 방장도 참가자 명단에 추가
+    await this.addParticipant(roomId, toUuid(userId));
+
     // 해당 방의 모든 참여자에게 브로드캐스트
     server.to(roomId).emit('game:recruit', {
       is_game_recruiting: true,

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -46,6 +46,19 @@ export class GameService {
   ) {}
 
   /**
+   * 전체 게임 목록 조회
+   */
+  async getAllGames() {
+    try {
+      const games = await this.gameRepository.find();
+      return { games };
+    } catch (error) {
+      this.logger.error('게임 목록 조회 중 오류 발생', error.stack);
+      throw error;
+    }
+  }
+
+  /**
    * 게임 모집 시작
    * @param server Socket.io 서버 인스턴스
    * @param roomId 방 ID

--- a/be/src/modules/room/room.module.ts
+++ b/be/src/modules/room/room.module.ts
@@ -1,13 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { User } from '../user/user.entity';
 import { RoomController } from './room.controller';
 import { RoomService } from './room.service';
 import { RoomGateway } from './room.gateway';
+import { GameModule } from '../game/game.module';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([User])], // RoomService에서 UserRepository 사용하므로 유지
+  imports: [AuthModule, TypeOrmModule.forFeature([User]), forwardRef(() => GameModule)], // RoomService에서 UserRepository 사용하므로 유지
   controllers: [RoomController],
   providers: [RoomService, RoomGateway],
   exports: [RoomService],

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException,
   OnModuleInit,
   HttpStatus,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -43,7 +44,7 @@ export class RoomService implements OnModuleInit {
   constructor(
     @Inject('REDIS_CLIENT') private readonly redisClient: RedisClientType,
     @InjectRepository(User) private readonly userRepository: Repository<User>,
-    private readonly gameService: GameService,
+    @Inject(forwardRef(() => GameService)) private readonly gameService: GameService,
   ) {}
 
   onModuleInit() {
@@ -155,7 +156,8 @@ export class RoomService implements OnModuleInit {
     await this.redisClient.del(`room:${roomId}:members:${uuid}`);
     await this.redisClient.sRem(`user:${uuid}:rooms`, roomId);
 
-    // TODO: 게임 참가자 목록에서도 제거 (게임 중일 경우)
+    // 게임 참가자 목록에서도 제거 (게임 중일 경우)
+    await this.gameService.leaveGame(roomId, userId);
 
     // 참여자 수 감소
     await this.updateCurrentParticipants(roomId);

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -31,6 +31,7 @@ import {
 import { toUuid } from '@src/common/utils/user-id';
 import { ROOM_TYPE, RoomType } from './room.type';
 import { Server } from 'socket.io';
+import { GameService } from '../game/game.service';
 
 @Injectable()
 export class RoomService implements OnModuleInit {
@@ -42,6 +43,7 @@ export class RoomService implements OnModuleInit {
   constructor(
     @Inject('REDIS_CLIENT') private readonly redisClient: RedisClientType,
     @InjectRepository(User) private readonly userRepository: Repository<User>,
+    private readonly gameService: GameService,
   ) {}
 
   onModuleInit() {
@@ -152,6 +154,8 @@ export class RoomService implements OnModuleInit {
     // 방 멤버 목록에서 제거 (Hash), 사용자의 참여 방 목록에서 제거 (Set)
     await this.redisClient.del(`room:${roomId}:members:${uuid}`);
     await this.redisClient.sRem(`user:${uuid}:rooms`, roomId);
+
+    // TODO: 게임 참가자 목록에서도 제거 (게임 중일 경우)
 
     // 참여자 수 감소
     await this.updateCurrentParticipants(roomId);

--- a/be/src/providers/database/migrations/1768816319000-SeedGames.ts
+++ b/be/src/providers/database/migrations/1768816319000-SeedGames.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeedGames1768816319000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 게임 데이터 삽입
+    await queryRunner.query(`
+      INSERT INTO \`game\` (\`id\`, \`title\`, \`type\`, \`description\`, \`min_participants\`, \`max_participants\`)
+      VALUES
+        (UUID_TO_BIN('550e8400-e29b-41d4-a716-446655440001'), '비커 채우기', 'competition', '제한 시간 동안 스페이스바를 빠르게 연타하여 비커를 채우세요!', 1, 10),
+        (UUID_TO_BIN('550e8400-e29b-41d4-a716-446655440002'), '반응 속도 테스트', 'competition', '화면에 나타나는 신호에 최대한 빨리 반응하세요!', 2, 6)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 게임 데이터 삭제
+    await queryRunner.query(`
+      DELETE FROM \`game\`
+      WHERE \`id\` IN (
+        UUID_TO_BIN('550e8400-e29b-41d4-a716-446655440001'),
+        UUID_TO_BIN('550e8400-e29b-41d4-a716-446655440002')
+      )
+    `);
+  }
+}

--- a/be/src/scripts/seed-games.ts
+++ b/be/src/scripts/seed-games.ts
@@ -1,0 +1,102 @@
+import { DataSource } from 'typeorm';
+import { Game, GameType } from '@src/modules/game/game.entity';
+import databaseConfig from '@src/providers/database/database.config';
+import { randomUUID } from 'crypto';
+
+/*
+게임 데이터 시드 스크립트
+
+로컬 환경에서 실행
+- cd be
+- pnpm seed:games
+
+도커 컨테이너 내부에서 실행
+- docker exec eryuk-server pnpm seed:games:docker
+*/
+
+const mockGames = [
+  {
+    id: randomUUID(),
+    title: '비커 채우기',
+    description: '제한 시간 동안 스페이스바를 빠르게 연타하여 비커를 채우세요!',
+    type: GameType.COMPETITION,
+    min_participants: 1,
+    max_participants: 10,
+  },
+  {
+    id: randomUUID(),
+    title: '반응 속도 테스트',
+    description: '화면에 나타나는 신호에 최대한 빨리 반응하세요!',
+    type: GameType.COMPETITION,
+    min_participants: 2,
+    max_participants: 6,
+  },
+];
+
+/**
+ * 게임 데이터 시드 스크립트
+ */
+async function seedGames() {
+  const dataSource = new DataSource(databaseConfig);
+
+  try {
+    await dataSource.initialize();
+    console.log('데이터베이스 연결 성공');
+
+    const gameRepository = dataSource.getRepository(Game);
+
+    // 기존 게임 확인
+    const existingGames = await gameRepository.count();
+    if (existingGames > 0) {
+      console.log(`⚠️  기존 게임 ${existingGames}개가 있습니다.`);
+      console.log('기존 데이터를 모두 삭제하고 새로 삽입합니다...');
+      // 기존 데이터 삭제
+      await gameRepository.clear();
+      console.log('기존 데이터 삭제 완료');
+    }
+
+    console.log(`총 ${mockGames.length}개의 게임을 삽입합니다...`);
+
+    // 게임 데이터 변환 및 삽입
+    const gamesToInsert = mockGames.map((mockGame) => {
+      const game = new Game();
+      game.id = mockGame.id;
+      game.title = mockGame.title;
+      game.description = mockGame.description;
+      game.type = mockGame.type;
+      game.min_participants = mockGame.min_participants;
+      game.max_participants = mockGame.max_participants;
+
+      return game;
+    });
+
+    // 배치 삽입 (성능 향상)
+    await gameRepository.save(gamesToInsert);
+
+    console.log(`✅ ${mockGames.length}개의 게임이 성공적으로 삽입되었습니다.`);
+    console.log('\n삽입된 게임 목록:');
+    mockGames.forEach((game, index) => {
+      console.log(`${index + 1}. ${game.title} (ID: ${game.id})`);
+      console.log(`   - 타입: ${game.type}`);
+      console.log(`   - 참가 인원: ${game.min_participants} ~ ${game.max_participants}명`);
+      console.log(`   - 설명: ${game.description}\n`);
+    });
+  } catch (error) {
+    console.error('❌ 게임 시드 중 오류 발생:', error);
+    throw error;
+  } finally {
+    await dataSource.destroy();
+    console.log('데이터베이스 연결 종료');
+  }
+}
+
+// 스크립트 실행
+seedGames()
+  .then(() => {
+    console.log('시드 완료');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('시드 실패:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**
- 게임 데이터 시딩 후 migration 추가
<br>

- 게임 참가 API 구현
- 게임 나가기 API 구현
- 게임 목록 조회 API 구현
<br>

- 로컬 방 퇴장 시 `room:roomId:game:players` 에서도 퇴장되도록 수정
- 방장이 게임 모집할 때 방장도 참가자 명단에 추가하도록 수정
<br>

- 에러 코드 상수화

**TODO**
- 방장이 게임 선택 시 Redis에 게임 정보 저장
  - `room:{roomId}:game` Hash에 id, title, type, description, max_participants, min_participants 저장
- 게임 참여 시 선택된 게임 가져오는 로직 검토 및 수정 `getSelectedGame`

---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- close #144 
- close #145 
- close #146 

---

### ✅ 기타 메모
> 논의할 내용

- 방장이 게임 리크루트 한 후에야 다른 사람들이 참여할 수 있는 프로세스로 이해하고 있습니다. 리크루트를 진행중인지 확인은 FE에서만 판별해서 버튼 비활성화/활성화만 해줘도 충분할까요? BE에서 따로 처리는 없어도 될까요?
  - Redis에 is_game_recruiting를 저장하여 검사
- 이제 user_id가 다 uuid로 된 것 같은데 toUuid 제거해도 될까요? + 앞으로는 로직에서 바로 userId로 사용해도 될까요?