### PR TITLE
[Feat] 게임 관련 API 구현 (선택, 준비 완료/해제, 시작, 닫기, 실시간 정보)

### DIFF
--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -129,7 +129,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
           // Redis 상태 복구
           await this.roomService.joinRoom(userId, roomId);
 
-          // 클라이언트에게 직접 room:join ACK 전송
+          // 클라이언트에게 직접 room:join 전송 (ACK (X) event push (O))
           const currentParticipants = await this.roomService.getCurrentParticipants(roomId);
           client.emit('room:join', { roomId, current_participants: currentParticipants });
         }

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -15,6 +15,7 @@ import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GLOBAL_ROOM_ID, USER_SESSION_EXPIRATION_TIME } from '@src/common/constants/constants';
+import { WS_EVENTS_AUTH, WS_EVENTS_ROOM, WS_EVENTS_CHAT } from '@src/common/constants/ws-events.constant';
 
 @UseFilters(new WsExceptionFilter()) // 필터
 @WebSocketGateway({ namespace: '/' })
@@ -131,7 +132,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
           // 클라이언트에게 직접 room:join 전송 (ACK (X) event push (O))
           const currentParticipants = await this.roomService.getCurrentParticipants(roomId);
-          client.emit('room:join', { roomId, current_participants: currentParticipants });
+          client.emit(WS_EVENTS_ROOM.JOIN, { roomId, current_participants: currentParticipants });
         }
 
         // 세션 복구 완료 후 세션 정보 삭제
@@ -201,7 +202,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
    * 인증 사용자 -> 익명 사용자 전환
    * WebSocket 연결은 유지하되, 참여자 수에서 제외
    */
-  @SubscribeMessage('auth:logout')
+  @SubscribeMessage(WS_EVENTS_AUTH.LOGOUT)
   async handleLogout(@ConnectedSocket() client: Socket) {
     try {
       const userId = client.data.userId;
@@ -257,7 +258,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
         timestamp: msg.create_date,
       }));
 
-      client.emit('chat:global:recents', {
+      client.emit(WS_EVENTS_CHAT.GLOBAL_RECENTS, {
         messages,
         current_participants: currentParticipants,
       });

--- a/be/src/common/constants/ws-events.constant.ts
+++ b/be/src/common/constants/ws-events.constant.ts
@@ -1,0 +1,69 @@
+/**
+ * 인증 관련 이벤트
+ */
+export const WS_EVENTS_AUTH = {
+  LOGOUT: 'auth:logout',
+} as const;
+
+/**
+ * 채팅 관련 이벤트
+ */
+export const WS_EVENTS_CHAT = {
+  // 수신 이벤트
+  GLOBAL_JOIN: 'chat:global:join',
+  GLOBAL_SEND: 'chat:global:send',
+  ROOM_SEND: 'chat:room:send',
+
+  // 송신 이벤트
+  GLOBAL_RECENTS: 'chat:global:recents',
+  GLOBAL_PARTICIPANTS_UPDATED: 'chat:global:participants-updated',
+  GLOBAL_NEW_MESSAGE: 'chat:global:new-message',
+  ROOM_NEW_MESSAGE: 'chat:room:new-message',
+} as const;
+
+/**
+ * 방(Room) 관련 이벤트
+ */
+export const WS_EVENTS_ROOM = {
+  // 수신 이벤트
+  JOIN: 'room:join',
+  LEAVE: 'room:leave',
+
+  // 송신 이벤트
+  PARTICIPANT_JOIN: 'room:participant:join',
+  PARTICIPANT_LEAVE: 'room:participant:leave',
+} as const;
+
+/**
+ * 게임 관련 이벤트
+ */
+export const WS_EVENTS_GAME = {
+  // 수신 이벤트
+  RECRUIT: 'game:recruit',
+  JOIN: 'game:join',
+  SELECT: 'game:select',
+  READY: 'game:ready',
+  UNREADY: 'game:unready',
+  START: 'game:start',
+  CLOSE: 'game:close',
+  LEAVE: 'game:leave',
+  REALTIME: 'game:realtime',
+
+  // 송신 이벤트
+  PARTICIPANT_RECRUIT: 'game:participant:recruit',
+  PARTICIPANT_SELECT: 'game:participant:select',
+  PARTICIPANT_JOIN: 'game:participant:join',
+  PARTICIPANT_READY: 'game:participant:ready',
+  PARTICIPANT_UNREADY: 'game:participant:unready',
+  PARTICIPANT_START: 'game:participant:start',
+  PARTICIPANT_CLOSE: 'game:participant:close',
+  PARTICIPANT_LEAVE: 'game:participant:leave',
+  PARTICIPANT_REALTIME: 'game:participant:realtime',
+} as const;
+
+/**
+ * 에러 이벤트
+ */
+export const WS_EVENTS_ERROR = {
+  ERROR: 'error',
+} as const;

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -283,6 +283,10 @@ export const LOG = {
       message: `게임 준비 완료: roomId=${roomId}, userId=${userId}`,
       level: 'log',
     }),
+    UNREADY: (roomId: string, userId: string): LogMessage => ({
+      message: `게임 준비 취소: roomId=${roomId}, userId=${userId}`,
+      level: 'log',
+    }),
     GAME_STATE_FETCH_ERROR: (roomId: string, error: string): LogMessage => ({
       message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
       level: 'error',

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -275,6 +275,10 @@ export const LOG = {
       message: `게임 참가 요청: roomId=${roomId}, userId=${userId}`,
       level: 'debug',
     }),
+    SELECT: (roomId: string, userId: string, gameId: string): LogMessage => ({
+      message: `게임 선택: roomId=${roomId}, userId=${userId}, gameId=${gameId}`,
+      level: 'log',
+    }),
     GAME_STATE_FETCH_ERROR: (roomId: string, error: string): LogMessage => ({
       message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
       level: 'error',

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -303,6 +303,22 @@ export const LOG = {
       message: `게임 모집 닫기: roomId=${roomId}, userId=${userId}`,
       level: 'log',
     }),
+    REALTIME_INPUT: (roomId: string, userId: string, delta: string): LogMessage => ({
+      message: `게임 실시간 입력: roomId=${roomId}, userId=${userId}, delta=${delta}`,
+      level: 'debug',
+    }),
+    REALTIME_INPUT_ERROR: (roomId: string, userId: string, error: string): LogMessage => ({
+      message: `게임 실시간 입력 처리 실패: roomId=${roomId}, userId=${userId}, error=${error}`,
+      level: 'error',
+    }),
+    REALTIME_BROADCAST: (roomId: string, highestScore: number, averageScore: string, ranks: string[]): LogMessage => ({
+      message: `게임 실시간 상태 브로드캐스트: roomId=${roomId}, highest_score=${highestScore}, average_score=${averageScore}, ranks_count=${ranks.length}`,
+      level: 'debug',
+    }),
+    REALTIME_BROADCAST_STOPPED: (roomId: string): LogMessage => ({
+      message: `게임 실시간 브로드캐스트 중지: roomId=${roomId}`,
+      level: 'log',
+    }),
   },
 } as const;
 

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -279,6 +279,10 @@ export const LOG = {
       message: `게임 선택: roomId=${roomId}, userId=${userId}, gameId=${gameId}`,
       level: 'log',
     }),
+    READY: (roomId: string, userId: string): LogMessage => ({
+      message: `게임 준비 완료: roomId=${roomId}, userId=${userId}`,
+      level: 'log',
+    }),
     GAME_STATE_FETCH_ERROR: (roomId: string, error: string): LogMessage => ({
       message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
       level: 'error',

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -299,6 +299,10 @@ export const LOG = {
       message: `게임 참가 취소: roomId=${roomId}, userId=${userId}`,
       level: 'log',
     }),
+    CLOSE: (roomId: string, userId: string): LogMessage => ({
+      message: `게임 모집 닫기: roomId=${roomId}, userId=${userId}`,
+      level: 'log',
+    }),
   },
 } as const;
 

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -287,6 +287,10 @@ export const LOG = {
       message: `게임 준비 취소: roomId=${roomId}, userId=${userId}`,
       level: 'log',
     }),
+    START: (roomId: string, userId: string, startTime: string): LogMessage => ({
+      message: `게임 시작 카운트다운: roomId=${roomId}, userId=${userId}, startTime=${startTime}`,
+      level: 'log',
+    }),
     GAME_STATE_FETCH_ERROR: (roomId: string, error: string): LogMessage => ({
       message: `게임 상태 조회 실패: roomId=${roomId}, error=${error}`,
       level: 'error',

--- a/be/src/modules/auth/auth.controller.ts
+++ b/be/src/modules/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Get, Body, Headers, UsePipes, ValidationPipe } from '
 import { AuthService } from './auth.service';
 import { MockAuthService } from './mock-auth.service';
 import { MockLoginDto, MockUserResponseDto } from './dto/mock-login.dto';
+import { GetMeResponseDto } from './dto/auth-response.dto';
 import { toUuid } from '@src/common/utils/user-id';
 
 @Controller('auth')
@@ -76,10 +77,6 @@ export class AuthController {
     // Service를 통해 MySQL에서 실제 사용자 정보 조회
     const user = await this.authService.getUserById(payload.userId);
 
-    return {
-      id: user.id,
-      nickname: user.nickname,
-      avatar: user.profile_image || '',
-    };
+    return new GetMeResponseDto(user);
   }
 }

--- a/be/src/modules/auth/auth.service.ts
+++ b/be/src/modules/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../user/user.entity';
 import { toUuid } from '@src/common/utils/user-id';
+import { UserInfoResponseDto, UserWithRoleResponseDto } from './dto/auth-response.dto';
 
 @Injectable()
 export class AuthService {
@@ -14,7 +15,7 @@ export class AuthService {
    * @returns 사용자 정보 (id, nickname, profile_image)
    * @throws NotFoundException 사용자를 찾을 수 없는 경우
    */
-  async getUserById(userId: string): Promise<{ id: string; nickname: string; profile_image: string | null }> {
+  async getUserById(userId: string): Promise<UserInfoResponseDto> {
     const uuid = toUuid(userId);
     const user = await this.userRepository.findOne({
       where: { id: uuid },
@@ -25,11 +26,7 @@ export class AuthService {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    return {
-      id: user.id,
-      nickname: user.nickname,
-      profile_image: user.profile_image,
-    };
+    return new UserInfoResponseDto(user);
   }
 
   /**
@@ -39,12 +36,7 @@ export class AuthService {
    * @returns 사용자 정보 (id, nickname, profile_image, role)
    * @throws NotFoundException 사용자를 찾을 수 없는 경우
    */
-  async getUserWithRole(userId: string): Promise<{
-    id: string;
-    nickname: string;
-    profile_image: string | null;
-    role: string;
-  }> {
+  async getUserWithRole(userId: string): Promise<UserWithRoleResponseDto> {
     const uuid = toUuid(userId);
     const user = await this.userRepository.findOne({
       where: { id: uuid },
@@ -55,11 +47,6 @@ export class AuthService {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    return {
-      id: user.id,
-      nickname: user.nickname,
-      profile_image: user.profile_image,
-      role: user.role,
-    };
+    return new UserWithRoleResponseDto(user);
   }
 }

--- a/be/src/modules/auth/dto/auth-response.dto.ts
+++ b/be/src/modules/auth/dto/auth-response.dto.ts
@@ -1,0 +1,32 @@
+export class UserInfoResponseDto {
+  id: string;
+  nickname: string;
+  profile_image: string | null;
+
+  constructor(data: { id: string; nickname: string; profile_image: string | null }) {
+    this.id = data.id;
+    this.nickname = data.nickname;
+    this.profile_image = data.profile_image;
+  }
+}
+
+export class UserWithRoleResponseDto extends UserInfoResponseDto {
+  role: string;
+
+  constructor(data: { id: string; nickname: string; profile_image: string | null; role: string }) {
+    super(data);
+    this.role = data.role;
+  }
+}
+
+export class GetMeResponseDto {
+  id: string;
+  nickname: string;
+  avatar: string;
+
+  constructor(data: { id: string; nickname: string; profile_image: string | null }) {
+    this.id = data.id;
+    this.nickname = data.nickname;
+    this.avatar = data.profile_image || '';
+  }
+}

--- a/be/src/modules/auth/dto/mock-login.dto.ts
+++ b/be/src/modules/auth/dto/mock-login.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty } from 'class-validator';
 
 export class MockLoginDto {
   @IsString()

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -7,6 +7,11 @@ import { ChatService } from './chat.service';
 import { RoomService } from '@src/modules/room/room.service';
 import { AuthService } from '@src/modules/auth/auth.service';
 import { GlobalChatSendDto, RoomChatSendDto } from './dto/chat-message.dto';
+import {
+  GlobalChatRecentMessageDto,
+  GlobalChatRecentsResponseDto,
+  GlobalChatParticipantsUpdatedResponseDto,
+} from './dto/chat-response.dto';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
@@ -52,7 +57,7 @@ export class ChatGateway {
         this.roomService.getCurrentParticipants(globalRoomId),
       ]);
 
-      const messages = recents.map((msg) => ({
+      const messages: GlobalChatRecentMessageDto[] = recents.map((msg) => ({
         message: msg.content,
         sender: {
           role: msg.role,
@@ -63,11 +68,11 @@ export class ChatGateway {
         timestamp: msg.create_date,
       }));
 
-      client.emit('chat:global:recents', { messages, current_participants: currentParticipants });
-      client.emit('chat:global:participants-updated', {
-        roomId: globalRoomId,
-        current_participants: currentParticipants,
-      });
+      const recentsResponse = new GlobalChatRecentsResponseDto(messages, currentParticipants);
+      client.emit('chat:global:recents', recentsResponse);
+
+      const participantsResponse = new GlobalChatParticipantsUpdatedResponseDto(globalRoomId, currentParticipants);
+      client.emit('chat:global:participants-updated', participantsResponse);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.WS.GLOBAL_CHAT_HANDLE_ERROR(errorMessage));

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -11,6 +11,8 @@ import {
   GlobalChatRecentMessageDto,
   GlobalChatRecentsResponseDto,
   GlobalChatParticipantsUpdatedResponseDto,
+  GlobalChatMessageResponseDto,
+  LocalChatMessageResponseDto,
 } from './dto/chat-response.dto';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
@@ -110,8 +112,13 @@ export class ChatGateway {
         profile_image: user.profile_image,
       };
 
-      // 메시지 브로드캐스트 (is_me 구분하여 전송)
+      // 다른 참여자들에게 브로드캐스트
       await this.chatService.broadcastGlobalChat(this.server, globalRoomId, userId, dto.message, senderInfo, client.id);
+
+      // 요청을 보낸 클라이언트에게 응답 반환 (is_me: true)
+      const timestamp = new Date().toISOString();
+      const responseToSender = new GlobalChatMessageResponseDto(dto.message, senderInfo, true, timestamp);
+      return responseToSender.data;
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -160,8 +167,13 @@ export class ChatGateway {
         profile_image: user.profile_image,
       };
 
-      // 메시지 브로드캐스트
+      // 참여자들에게 브로드캐스트
       await this.chatService.broadcastRoomChat(this.server, dto.room_id, userId, dto.message, senderInfo, client.id);
+
+      // 요청을 보낸 클라이언트에게 응답 반환 (is_me: true)
+      const timestamp = new Date().toISOString();
+      const responseToSender = new LocalChatMessageResponseDto(dto.room_id, dto.message, senderInfo, true, timestamp);
+      return responseToSender.data;
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -19,6 +19,7 @@ import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
+import { WS_EVENTS_CHAT, WS_EVENTS_ERROR } from '@src/common/constants/ws-events.constant';
 
 @UseFilters(new WsExceptionFilter())
 @WebSocketGateway({ namespace: '/' })
@@ -47,7 +48,7 @@ export class ChatGateway {
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
   ) {}
 
-  @SubscribeMessage('chat:global:join')
+  @SubscribeMessage(WS_EVENTS_CHAT.GLOBAL_JOIN)
   async handleGlobalChatJoin(@ConnectedSocket() client: Socket) {
     try {
       const globalRoomId = GLOBAL_ROOM_ID;
@@ -71,10 +72,10 @@ export class ChatGateway {
       }));
 
       const recentsResponse = new GlobalChatRecentsResponseDto(messages, currentParticipants);
-      client.emit('chat:global:recents', recentsResponse);
+      client.emit(WS_EVENTS_CHAT.GLOBAL_RECENTS, recentsResponse);
 
       const participantsResponse = new GlobalChatParticipantsUpdatedResponseDto(globalRoomId, currentParticipants);
-      client.emit('chat:global:participants-updated', participantsResponse);
+      client.emit(WS_EVENTS_CHAT.GLOBAL_PARTICIPANTS_UPDATED, participantsResponse);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.WS.GLOBAL_CHAT_HANDLE_ERROR(errorMessage));
@@ -82,7 +83,7 @@ export class ChatGateway {
   }
 
   // 글로벌 채팅 메시지 수신 및 브로드캐스트
-  @SubscribeMessage('chat:global:send')
+  @SubscribeMessage(WS_EVENTS_CHAT.GLOBAL_SEND)
   async handleGlobalChat(@ConnectedSocket() client: Socket, @MessageBody() dto: GlobalChatSendDto) {
     try {
       const userId = client.data.userId;
@@ -91,7 +92,7 @@ export class ChatGateway {
       // 권한 검증: 인증되지 않은 사용자는 메시지 송신 불가능
       if (!isAuthenticated || !userId) {
         logMessage(this.logger, LOG.CHAT.UNAUTH_SEND(client.id));
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -99,7 +100,7 @@ export class ChatGateway {
       const globalRoomId = await this.roomService.getUserGlobalRoom(userId);
       if (!globalRoomId) {
         logMessage(this.logger, LOG.CHAT.NOT_MEMBER_SEND(userId, 'global'));
-        client.emit('error', createWsError('NOT_FOUND', '글로벌 채팅방에 참여하지 않았습니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('NOT_FOUND', '글로벌 채팅방에 참여하지 않았습니다.'));
         return;
       }
 
@@ -126,7 +127,7 @@ export class ChatGateway {
 
       const errorResponse = createWsErrorResponse(error, '메시지 전송 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -138,7 +139,7 @@ export class ChatGateway {
    * 방 채팅 메시지 수신 및 브로드캐스트
    * 요구사항: 해당 방의 참여자만 메시지 송신 가능
    */
-  @SubscribeMessage('chat:room:send')
+  @SubscribeMessage(WS_EVENTS_CHAT.ROOM_SEND)
   async handleRoomChat(@ConnectedSocket() client: Socket, @MessageBody() dto: RoomChatSendDto) {
     try {
       const userId = client.data.userId;
@@ -147,7 +148,7 @@ export class ChatGateway {
       // 권한 검증: 인증되지 않은 사용자는 메시지 송신 불가능
       if (!isAuthenticated || !userId) {
         logMessage(this.logger, LOG.CHAT.UNAUTH_ROOM_SEND(client.id));
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -155,7 +156,7 @@ export class ChatGateway {
       const isInRoom = await this.roomService.isUserInRoom(userId, dto.room_id);
       if (!isInRoom) {
         logMessage(this.logger, LOG.CHAT.NOT_MEMBER_SEND(userId, dto.room_id));
-        client.emit('error', createWsError('NOT_FOUND', '해당 방에 참여하지 않았습니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('NOT_FOUND', '해당 방에 참여하지 않았습니다.'));
         return;
       }
 
@@ -181,7 +182,7 @@ export class ChatGateway {
 
       const errorResponse = createWsErrorResponse(error, '메시지 전송 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -5,6 +5,7 @@ import { GlobalChatMessageResponseDto, LocalChatMessageResponseDto } from './dto
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
 import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
+import { WS_EVENTS_CHAT } from '@src/common/constants/ws-events.constant';
 
 @Injectable()
 export class ChatService {
@@ -33,7 +34,7 @@ export class ChatService {
 
     // 다른 사용자들에게는 is_me: false로 전송
     const responseToOthers = new GlobalChatMessageResponseDto(message, senderInfo, false, timestamp);
-    server.to(roomId).except(senderSocketId).emit('chat:global:new-message', responseToOthers.data);
+    server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.GLOBAL_NEW_MESSAGE, responseToOthers.data);
 
     // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
     if (roomId === GLOBAL_ROOM_ID) {
@@ -56,7 +57,7 @@ export class ChatService {
 
     // 다른 사용자들에게는 is_me: false로 전송
     const responseToOthers = new LocalChatMessageResponseDto(roomId, message, senderInfo, false, timestamp);
-    server.to(roomId).except(senderSocketId).emit('chat:room:new-message', responseToOthers.data);
+    server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.ROOM_NEW_MESSAGE, responseToOthers.data);
 
     logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
   }

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -31,19 +31,9 @@ export class ChatService {
   ): Promise<void> {
     const timestamp = new Date().toISOString();
 
-    // 메시지를 보낸 사용자에게는 is_me: true로 전송
-    const responseToSender = new GlobalChatMessageResponseDto(message, senderInfo, true, timestamp);
-
     // 다른 사용자들에게는 is_me: false로 전송
     const responseToOthers = new GlobalChatMessageResponseDto(message, senderInfo, false, timestamp);
-
-    // 메시지를 보낸 클라이언트에게만 is_me: true로 전송
-    server.to(senderSocketId).emit(responseToSender.event, responseToSender.data);
-    this.logger.debug(`메시지 발신자에게 전송: socketId=${senderSocketId}, is_me=true`);
-
-    // 같은 방의 다른 클라이언트들에게는 is_me: false로 전송
-    server.to(roomId).except(senderSocketId).emit(responseToOthers.event, responseToOthers.data);
-    this.logger.debug(`다른 클라이언트들에게 브로드캐스트: roomId=${roomId}, except=${senderSocketId}, is_me=false`);
+    server.to(roomId).except(senderSocketId).emit('chat:global:new-message', responseToOthers.data);
 
     // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
     if (roomId === GLOBAL_ROOM_ID) {
@@ -64,19 +54,9 @@ export class ChatService {
   ): Promise<void> {
     const timestamp = new Date().toISOString();
 
-    // 메시지를 보낸 사용자에게는 is_me: true로 전송
-    const responseToSender = new LocalChatMessageResponseDto(roomId, message, senderInfo, true, timestamp);
-
     // 다른 사용자들에게는 is_me: false로 전송
     const responseToOthers = new LocalChatMessageResponseDto(roomId, message, senderInfo, false, timestamp);
-
-    // 메시지를 보낸 클라이언트에게만 is_me: true로 전송
-    server.to(senderSocketId).emit(responseToSender.event, responseToSender.data);
-    this.logger.debug(`메시지 발신자에게 전송: socketId=${senderSocketId}, is_me=true`);
-
-    // 같은 방의 다른 클라이언트들에게는 is_me: false로 전송
-    server.to(roomId).except(senderSocketId).emit(responseToOthers.event, responseToOthers.data);
-    this.logger.debug(`다른 클라이언트들에게 브로드캐스트: roomId=${roomId}, except=${senderSocketId}, is_me=false`);
+    server.to(roomId).except(senderSocketId).emit('chat:room:new-message', responseToOthers.data);
 
     logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
   }

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -32,34 +32,10 @@ export class ChatService {
     const timestamp = new Date().toISOString();
 
     // 메시지를 보낸 사용자에게는 is_me: true로 전송
-    const responseToSender: GlobalChatMessageResponseDto = {
-      event: 'chat:global:new-message',
-      data: {
-        message,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image,
-          is_me: true,
-        },
-        timestamp,
-      },
-    };
+    const responseToSender = new GlobalChatMessageResponseDto(message, senderInfo, true, timestamp);
 
     // 다른 사용자들에게는 is_me: false로 전송
-    const responseToOthers: GlobalChatMessageResponseDto = {
-      event: 'chat:global:new-message',
-      data: {
-        message,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image,
-          is_me: false,
-        },
-        timestamp,
-      },
-    };
+    const responseToOthers = new GlobalChatMessageResponseDto(message, senderInfo, false, timestamp);
 
     // 메시지를 보낸 클라이언트에게만 is_me: true로 전송
     server.to(senderSocketId).emit(responseToSender.event, responseToSender.data);
@@ -89,36 +65,10 @@ export class ChatService {
     const timestamp = new Date().toISOString();
 
     // 메시지를 보낸 사용자에게는 is_me: true로 전송
-    const responseToSender: LocalChatMessageResponseDto = {
-      event: 'chat:room:new-message',
-      data: {
-        room_id: roomId,
-        message,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image,
-          is_me: true,
-        },
-        timestamp,
-      },
-    };
+    const responseToSender = new LocalChatMessageResponseDto(roomId, message, senderInfo, true, timestamp);
 
     // 다른 사용자들에게는 is_me: false로 전송
-    const responseToOthers: LocalChatMessageResponseDto = {
-      event: 'chat:room:new-message',
-      data: {
-        room_id: roomId,
-        message,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image,
-          is_me: false,
-        },
-        timestamp,
-      },
-    };
+    const responseToOthers = new LocalChatMessageResponseDto(roomId, message, senderInfo, false, timestamp);
 
     // 메시지를 보낸 클라이언트에게만 is_me: true로 전송
     server.to(senderSocketId).emit(responseToSender.event, responseToSender.data);

--- a/be/src/modules/chat/dto/chat-response.dto.ts
+++ b/be/src/modules/chat/dto/chat-response.dto.ts
@@ -1,6 +1,5 @@
 // 글로벌 채팅 메시지 응답 DTO
 export class GlobalChatMessageResponseDto {
-  event: 'chat:global:new-message' = 'chat:global:new-message';
   data: {
     message: string;
     sender: {
@@ -33,7 +32,6 @@ export class GlobalChatMessageResponseDto {
 
 // 로컬 채팅 메시지 응답 DTO
 export class LocalChatMessageResponseDto {
-  event: 'chat:room:new-message' = 'chat:room:new-message';
   data: {
     room_id: string;
     message: string;

--- a/be/src/modules/chat/dto/chat-response.dto.ts
+++ b/be/src/modules/chat/dto/chat-response.dto.ts
@@ -1,6 +1,6 @@
 // 글로벌 채팅 메시지 응답 DTO
-export interface GlobalChatMessageResponseDto {
-  event: 'chat:global:new-message';
+export class GlobalChatMessageResponseDto {
+  event: 'chat:global:new-message' = 'chat:global:new-message';
   data: {
     message: string;
     sender: {
@@ -11,11 +11,29 @@ export interface GlobalChatMessageResponseDto {
     };
     timestamp: string;
   };
+
+  constructor(
+    message: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    isMe: boolean,
+    timestamp: string,
+  ) {
+    this.data = {
+      message,
+      sender: {
+        role: senderInfo.role,
+        nickname: senderInfo.nickname,
+        profile_image: senderInfo.profile_image,
+        is_me: isMe,
+      },
+      timestamp,
+    };
+  }
 }
 
 // 로컬 채팅 메시지 응답 DTO
-export interface LocalChatMessageResponseDto {
-  event: 'chat:room:new-message';
+export class LocalChatMessageResponseDto {
+  event: 'chat:room:new-message' = 'chat:room:new-message';
   data: {
     room_id: string;
     message: string;
@@ -27,4 +45,57 @@ export interface LocalChatMessageResponseDto {
     };
     timestamp: string;
   };
+
+  constructor(
+    roomId: string,
+    message: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    isMe: boolean,
+    timestamp: string,
+  ) {
+    this.data = {
+      room_id: roomId,
+      message,
+      sender: {
+        role: senderInfo.role,
+        nickname: senderInfo.nickname,
+        profile_image: senderInfo.profile_image,
+        is_me: isMe,
+      },
+      timestamp,
+    };
+  }
+}
+
+// 글로벌 채팅 최근 메시지 조회 응답 DTO
+export class GlobalChatRecentMessageDto {
+  message: string;
+  sender: {
+    role: string;
+    nickname: string;
+    profile_image: string;
+    is_me: boolean;
+  };
+  timestamp: string;
+}
+
+export class GlobalChatRecentsResponseDto {
+  messages: GlobalChatRecentMessageDto[];
+  current_participants: number;
+
+  constructor(messages: GlobalChatRecentMessageDto[], currentParticipants: number) {
+    this.messages = messages;
+    this.current_participants = currentParticipants;
+  }
+}
+
+// 글로벌 채팅 참여자 수 업데이트 응답 DTO
+export class GlobalChatParticipantsUpdatedResponseDto {
+  roomId: string;
+  current_participants: number;
+
+  constructor(roomId: string, currentParticipants: number) {
+    this.roomId = roomId;
+    this.current_participants = currentParticipants;
+  }
 }

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -1,0 +1,65 @@
+export class GameInfoResponseDto {
+  id: string;
+  title: string;
+  type: string;
+  description?: string;
+  min_participants: number;
+  max_participants: number;
+}
+
+export class GameListResponseDto {
+  games: GameInfoResponseDto[];
+}
+
+export class GameParticipantDto {
+  user_id: string;
+  nickname: string;
+  profile_image: string;
+  is_ready: boolean;
+  score?: string;
+  rank?: string;
+}
+
+export class GamePlayerDto {
+  nickname: string;
+  profile_image: string;
+  is_ready: boolean;
+}
+
+export class GameHostDto {
+  nickname: string;
+  profile_image: string;
+}
+
+export class GameInfoPayloadDto {
+  id: string;
+  title: string;
+  description?: string;
+  type: string;
+  min_participants: string;
+  max_participants: string;
+}
+
+export class GameJoinAckResponseDto {
+  current_players: string;
+  max_players: string;
+  host: GameHostDto;
+  players: GamePlayerDto[];
+  game?: GameInfoPayloadDto;
+
+  constructor(
+    currentPlayers: number,
+    maxPlayers: number,
+    host: GameHostDto,
+    players: GamePlayerDto[],
+    game?: GameInfoPayloadDto,
+  ) {
+    this.current_players = currentPlayers.toString();
+    this.max_players = maxPlayers.toString();
+    this.host = host;
+    this.players = players;
+    if (game) {
+      this.game = game;
+    }
+  }
+}

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -80,3 +80,8 @@ export class GameReadyBroadcastDto {
   player_id: string;
   is_ready: boolean;
 }
+
+// 게임 시작 브로드캐스트
+export class GameStartBroadcastDto {
+  start_time: string;
+}

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -85,3 +85,12 @@ export class GameReadyBroadcastDto {
 export class GameStartBroadcastDto {
   start_time: string;
 }
+
+// 게임 닫기 브로드캐스트
+export class GameCloseBroadcastDto {
+  is_game_recruiting: boolean;
+
+  constructor(isGameRecruiting: boolean) {
+    this.is_game_recruiting = isGameRecruiting;
+  }
+}

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -74,3 +74,9 @@ export class GameJoinAckResponseDto {
     }
   }
 }
+
+// 게임 준비 완료 브로드캐스트
+export class GameReadyBroadcastDto {
+  player_id: string;
+  is_ready: boolean;
+}

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -1,3 +1,4 @@
+// 게임 목록 조회
 export class GameInfoResponseDto {
   id: string;
   title: string;
@@ -11,6 +12,7 @@ export class GameListResponseDto {
   games: GameInfoResponseDto[];
 }
 
+// 게임 참가자 정보
 export class GameParticipantDto {
   user_id: string;
   nickname: string;
@@ -20,17 +22,20 @@ export class GameParticipantDto {
   rank?: string;
 }
 
+// 게임 참가자 정보 (게임 플레이어)
 export class GamePlayerDto {
   nickname: string;
   profile_image: string;
   is_ready: boolean;
 }
 
+// 게임 호스트 정보
 export class GameHostDto {
   nickname: string;
   profile_image: string;
 }
 
+// 게임 정보
 export class GameInfoPayloadDto {
   id: string;
   title: string;
@@ -40,6 +45,12 @@ export class GameInfoPayloadDto {
   max_participants: string;
 }
 
+// 게임 선택 브로드캐스트
+export class GameSelectBroadcastDto {
+  game: GameInfoPayloadDto;
+}
+
+// 게임 참가 응답
 export class GameJoinAckResponseDto {
   current_players: string;
   max_players: string;

--- a/be/src/modules/game/dto/game-response.dto.ts
+++ b/be/src/modules/game/dto/game-response.dto.ts
@@ -94,3 +94,10 @@ export class GameCloseBroadcastDto {
     this.is_game_recruiting = isGameRecruiting;
   }
 }
+
+// 게임 실시간 상태 브로드캐스트
+export class GameRealtimeBroadcastDto {
+  highest_score: string;
+  average_score: string;
+  ranks: string[];
+}

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsUUID } from 'class-validator';
+import { IsString, IsNotEmpty, IsUUID, IsNumberString } from 'class-validator';
 
 export class GameRoomIdDto {
   @IsString()
@@ -17,4 +17,15 @@ export class GameSelectDto {
   @IsNotEmpty()
   @IsUUID()
   game_id: string;
+}
+
+export class GameRealtimeInputDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  room_id: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  delta: string;
 }

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -13,3 +13,15 @@ export class GameJoinDto {
   @IsUUID()
   room_id: string;
 }
+
+export class GameSelectDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  room_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  game_id: string;
+}

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -13,16 +13,3 @@ export class GameJoinDto {
   @IsUUID()
   room_id: string;
 }
-
-export interface GameInfoDto {
-  id: string;
-  title: string;
-  type: string;
-  description: string;
-  min_participants: number;
-  max_participants: number;
-}
-
-export class GameListResponseDto {
-  games: GameInfoDto[];
-}

--- a/be/src/modules/game/dto/game.dto.ts
+++ b/be/src/modules/game/dto/game.dto.ts
@@ -1,13 +1,6 @@
 import { IsString, IsNotEmpty, IsUUID } from 'class-validator';
 
-export class GameRecruitDto {
-  @IsString()
-  @IsNotEmpty()
-  @IsUUID()
-  room_id: string;
-}
-
-export class GameJoinDto {
+export class GameRoomIdDto {
   @IsString()
   @IsNotEmpty()
   @IsUUID()

--- a/be/src/modules/game/game.controller.ts
+++ b/be/src/modules/game/game.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { GameService } from './game.service';
-import { GameListResponseDto } from './dto/game.dto';
+import { GameListResponseDto } from './dto/game-response.dto';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
 
 @Controller('games')

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -172,6 +172,32 @@ export class GameGateway {
   }
 
   /**
+   * 게임 시작 (카운트다운)
+   */
+  @SubscribeMessage('game:start')
+  async handleGameStart(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      await this.gameService.startGame(this.server, dto.room_id, userId);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 시작 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
    * 게임 나가기
    */
   @SubscribeMessage('game:leave')

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -198,7 +198,33 @@ export class GameGateway {
   }
 
   /**
-   * 게임 나가기
+   * 게임 모집 닫기 (방장)
+   */
+  @SubscribeMessage('game:close')
+  async handleGameClose(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      await this.gameService.closeGame(this.server, dto.room_id, userId);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 모집 닫기 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
+   * 게임 나가기 (참가자)
    */
   @SubscribeMessage('game:leave')
   async handleGameLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -5,7 +5,7 @@ import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
-import { GameRoomIdDto, GameSelectDto } from './dto/game.dto';
+import { GameRoomIdDto, GameSelectDto, GameRealtimeInputDto } from './dto/game.dto';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
 
 @UseFilters(new WsExceptionFilter())
@@ -250,6 +250,34 @@ export class GameGateway {
       });
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 나가기 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
+   * 게임 실시간 입력 처리
+   * - 클라이언트로부터 100ms 주기로 쓰로틀된 입력 받음
+   * - 서버에서 300ms 주기로 배치하여 브로드캐스트
+   */
+  @SubscribeMessage('game:realtime')
+  async handleGameRealtime(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRealtimeInputDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      await this.gameService.handleRealtimeInput(this.server, dto.room_id, userId, dto.delta);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 실시간 입력 처리 중 문제가 발생했습니다.');
       try {
         client.emit('error', errorResponse);
         return;

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -5,7 +5,7 @@ import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
-import { GameRecruitDto, GameJoinDto, GameSelectDto } from './dto/game.dto';
+import { GameRoomIdDto, GameSelectDto } from './dto/game.dto';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
 
 @UseFilters(new WsExceptionFilter())
@@ -34,7 +34,7 @@ export class GameGateway {
    * 게임 플레이어 모집
    */
   @SubscribeMessage('game:recruit')
-  async handleGameRecruit(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRecruitDto) {
+  async handleGameRecruit(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
@@ -68,7 +68,7 @@ export class GameGateway {
    * 게임 참가
    */
   @SubscribeMessage('game:join')
-  async handleGameJoin(@ConnectedSocket() client: Socket, @MessageBody() dto: GameJoinDto) {
+  async handleGameJoin(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
@@ -80,6 +80,7 @@ export class GameGateway {
 
       const payload = await this.gameService.joinGame(this.server, dto.room_id, userId);
 
+      // 요청한 클라이언트에게 응답 전송
       client.emit('game:join', payload);
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
@@ -106,9 +107,35 @@ export class GameGateway {
         return;
       }
 
-      const payload = await this.gameService.selectGame(this.server, dto.room_id, userId, dto.game_id);
+      await this.gameService.selectGame(this.server, dto.room_id, userId, dto.game_id);
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 선택 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
+   * 게임 준비 완료
+   */
+  @SubscribeMessage('game:ready')
+  async handleGameReady(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      await this.gameService.readyGame(this.server, dto.room_id, userId);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 준비 중 문제가 발생했습니다.');
       try {
         client.emit('error', errorResponse);
         return;
@@ -122,7 +149,7 @@ export class GameGateway {
    * 게임 나가기
    */
   @SubscribeMessage('game:leave')
-  async handleGameLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: GameJoinDto) {
+  async handleGameLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -146,6 +146,32 @@ export class GameGateway {
   }
 
   /**
+   * 게임 준비 해제
+   */
+  @SubscribeMessage('game:unready')
+  async handleGameUnready(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      await this.gameService.unreadyGame(this.server, dto.room_id, userId);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 준비 해제 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
    * 게임 나가기
    */
   @SubscribeMessage('game:leave')

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -5,8 +5,7 @@ import { WsExceptionFilter } from '@src/common/filters/ws-exception.filter';
 import { WsJsonParsePipe } from '@src/common/pipes/ws-json-parse.pipe';
 import { ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
-import { GameRecruitDto } from './dto/game.dto';
-import { GameJoinDto } from './dto/game.dto';
+import { GameRecruitDto, GameJoinDto, GameSelectDto } from './dto/game.dto';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
 
 @UseFilters(new WsExceptionFilter())
@@ -84,6 +83,32 @@ export class GameGateway {
       client.emit('game:join', payload);
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
+      try {
+        client.emit('error', errorResponse);
+        return;
+      } catch (emitError) {
+        this.logger.warn('에러 메시지 전송 실패', emitError);
+      }
+    }
+  }
+
+  /**
+   * 게임 선택
+   */
+  @SubscribeMessage('game:select')
+  async handleGameSelect(@ConnectedSocket() client: Socket, @MessageBody() dto: GameSelectDto) {
+    try {
+      const userId = client.data.userId;
+      const isAuthenticated = client.data.authenticated;
+
+      if (!isAuthenticated || !userId) {
+        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        return;
+      }
+
+      const payload = await this.gameService.selectGame(this.server, dto.room_id, userId, dto.game_id);
+    } catch (error) {
+      const errorResponse = createWsErrorResponse(error, '게임 선택 중 문제가 발생했습니다.');
       try {
         client.emit('error', errorResponse);
         return;

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -7,6 +7,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
 import { GameRoomIdDto, GameSelectDto, GameRealtimeInputDto } from './dto/game.dto';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
+import { WS_EVENTS_GAME, WS_EVENTS_ERROR } from '@src/common/constants/ws-events.constant';
 
 @UseFilters(new WsExceptionFilter())
 @WebSocketGateway({ namespace: '/' })
@@ -33,7 +34,7 @@ export class GameGateway {
   /**
    * 게임 플레이어 모집
    */
-  @SubscribeMessage('game:recruit')
+  @SubscribeMessage(WS_EVENTS_GAME.RECRUIT)
   async handleGameRecruit(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
@@ -41,7 +42,7 @@ export class GameGateway {
 
       // 권한 검증: 인증되지 않은 사용자는 게임 모집 불가능
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -56,7 +57,7 @@ export class GameGateway {
       // 모든 예외를 일관되게 처리
       const errorResponse = createWsErrorResponse(error, '게임 모집 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -67,14 +68,14 @@ export class GameGateway {
   /**
    * 게임 참가
    */
-  @SubscribeMessage('game:join')
+  @SubscribeMessage(WS_EVENTS_GAME.JOIN)
   async handleGameJoin(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -85,7 +86,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -96,14 +97,14 @@ export class GameGateway {
   /**
    * 게임 선택
    */
-  @SubscribeMessage('game:select')
+  @SubscribeMessage(WS_EVENTS_GAME.SELECT)
   async handleGameSelect(@ConnectedSocket() client: Socket, @MessageBody() dto: GameSelectDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -111,7 +112,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 선택 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -122,14 +123,14 @@ export class GameGateway {
   /**
    * 게임 준비 완료
    */
-  @SubscribeMessage('game:ready')
+  @SubscribeMessage(WS_EVENTS_GAME.READY)
   async handleGameReady(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -137,7 +138,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 준비 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -148,14 +149,14 @@ export class GameGateway {
   /**
    * 게임 준비 해제
    */
-  @SubscribeMessage('game:unready')
+  @SubscribeMessage(WS_EVENTS_GAME.UNREADY)
   async handleGameUnready(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -163,7 +164,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 준비 해제 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -174,14 +175,14 @@ export class GameGateway {
   /**
    * 게임 시작 (카운트다운)
    */
-  @SubscribeMessage('game:start')
+  @SubscribeMessage(WS_EVENTS_GAME.START)
   async handleGameStart(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -189,7 +190,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 시작 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -200,14 +201,14 @@ export class GameGateway {
   /**
    * 게임 모집 닫기 (방장)
    */
-  @SubscribeMessage('game:close')
+  @SubscribeMessage(WS_EVENTS_GAME.CLOSE)
   async handleGameClose(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -215,7 +216,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 모집 닫기 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -226,14 +227,14 @@ export class GameGateway {
   /**
    * 게임 나가기 (참가자)
    */
-  @SubscribeMessage('game:leave')
+  @SubscribeMessage(WS_EVENTS_GAME.LEAVE)
   async handleGameLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRoomIdDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -244,14 +245,14 @@ export class GameGateway {
       const participantCount = await this.gameService.getParticipantCount(dto.room_id);
 
       // 브로드캐스트
-      this.server.to(dto.room_id).emit('game:participant:leave', {
+      this.server.to(dto.room_id).emit(WS_EVENTS_GAME.PARTICIPANT_LEAVE, {
         left_user_id: userId,
         participant_count: participantCount,
       });
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 나가기 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);
@@ -264,14 +265,14 @@ export class GameGateway {
    * - 클라이언트로부터 100ms 주기로 쓰로틀된 입력 받음
    * - 서버에서 300ms 주기로 배치하여 브로드캐스트
    */
-  @SubscribeMessage('game:realtime')
+  @SubscribeMessage(WS_EVENTS_GAME.REALTIME)
   async handleGameRealtime(@ConnectedSocket() client: Socket, @MessageBody() dto: GameRealtimeInputDto) {
     try {
       const userId = client.data.userId;
       const isAuthenticated = client.data.authenticated;
 
       if (!isAuthenticated || !userId) {
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -279,7 +280,7 @@ export class GameGateway {
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 실시간 입력 처리 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -49,9 +49,9 @@ export class GameGateway {
       await this.gameService.startGameRecruiting(this.server, dto.room_id, userId);
 
       // 요청한 클라이언트에게 응답 전송
-      client.emit('game:recruit', {
+      return {
         room_id: dto.room_id,
-      });
+      };
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorResponse = createWsErrorResponse(error, '게임 모집 중 문제가 발생했습니다.');
@@ -81,7 +81,7 @@ export class GameGateway {
       const payload = await this.gameService.joinGame(this.server, dto.room_id, userId);
 
       // 요청한 클라이언트에게 응답 전송
-      client.emit('game:join', payload);
+      return { ...payload };
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
       try {
@@ -244,7 +244,7 @@ export class GameGateway {
       const participantCount = await this.gameService.getParticipantCount(dto.room_id);
 
       // 브로드캐스트
-      this.server.to(dto.room_id).emit('game:leave', {
+      this.server.to(dto.room_id).emit('game:participant:leave', {
         left_user_id: userId,
         participant_count: participantCount,
       });

--- a/be/src/modules/game/game.gateway.ts
+++ b/be/src/modules/game/game.gateway.ts
@@ -81,7 +81,7 @@ export class GameGateway {
       const payload = await this.gameService.joinGame(this.server, dto.room_id, userId);
 
       // 요청한 클라이언트에게 응답 전송
-      return { ...payload };
+      return payload;
     } catch (error) {
       const errorResponse = createWsErrorResponse(error, '게임 참가 중 문제가 발생했습니다.');
       try {

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -135,7 +135,7 @@ export class GameService {
     await this.redisClient.hSet(this.getGameKey(roomId), cachePayload);
 
     const roomBroadcast: GameSelectBroadcastDto = { game: broadcastPayload };
-    server.to(roomId).emit('game:select', roomBroadcast);
+    server.to(roomId).emit('game:participant:select', roomBroadcast);
 
     logMessage(this.logger, LOG.GAME.SELECT(roomId, userId, gameId));
 
@@ -233,7 +233,7 @@ export class GameService {
       player_id: userId,
       is_ready: true,
     };
-    server.to(roomId).emit('game:ready', readyBroadcast);
+    server.to(roomId).emit('game:participant:ready', readyBroadcast);
 
     logMessage(this.logger, LOG.GAME.READY(roomId, userId));
   }
@@ -256,7 +256,7 @@ export class GameService {
       player_id: userId,
       is_ready: false,
     };
-    server.to(roomId).emit('game:unready', unreadyBroadcast);
+    server.to(roomId).emit('game:participant:unready', unreadyBroadcast);
 
     logMessage(this.logger, LOG.GAME.UNREADY(roomId, userId));
   }
@@ -299,7 +299,7 @@ export class GameService {
     await this.redisClient.hSet(this.getGameKey(roomId), { start_time: startTime, is_recruiting: '0' });
 
     const broadcast: GameStartBroadcastDto = { start_time: startTime };
-    server.to(roomId).emit('game:start', broadcast);
+    server.to(roomId).emit('game:participant:start', broadcast);
 
     logMessage(this.logger, LOG.GAME.START(roomId, userId, startTime));
 

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -8,32 +8,14 @@ import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { toUuid } from '@src/common/utils/user-id';
 import { Game } from './game.entity';
-
-interface GameParticipant {
-  user_id: string;
-  nickname: string;
-  profile_image: string;
-  is_ready: boolean;
-  score?: string;
-  rank?: string;
-}
-
-interface GameInfoPayload {
-  id: string;
-  title: string;
-  description?: string;
-  type: string;
-  min_participants: string;
-  max_participants: string;
-}
-
-interface GameJoinAckPayload {
-  current_players: string;
-  max_players: string;
-  host: { nickname: string; profile_image: string };
-  players: Array<{ nickname: string; profile_image: string; is_ready: boolean }>;
-  game?: GameInfoPayload;
-}
+import {
+  GameListResponseDto,
+  GameParticipantDto,
+  GameInfoPayloadDto,
+  GameJoinAckResponseDto,
+  GameHostDto,
+  GamePlayerDto,
+} from './dto/game-response.dto';
 
 @Injectable()
 export class GameService {
@@ -48,7 +30,7 @@ export class GameService {
   /**
    * 전체 게임 목록 조회
    */
-  async getAllGames() {
+  async getAllGames(): Promise<GameListResponseDto> {
     try {
       const games = await this.gameRepository.find();
       return { games };
@@ -97,7 +79,7 @@ export class GameService {
   /**
    * 게임 참가 처리 및 상태 반환
    */
-  async joinGame(server: Server, roomId: string, userId: string): Promise<GameJoinAckPayload> {
+  async joinGame(server: Server, roomId: string, userId: string): Promise<GameJoinAckResponseDto> {
     const uuid = toUuid(userId);
 
     logMessage(this.logger, LOG.GAME.JOIN_REQUEST(roomId, uuid));
@@ -122,25 +104,23 @@ export class GameService {
       this.getSelectedGame(roomId),
     ]);
 
-    // TODO: 방장이 게임 모집할 때 방장도 참가자 명단에 추가해줘야함!
     const currentPlayers = participants.length;
 
     const hostProfile = this.extractHostProfile(roomInfo.host_id, participants, roomInfo.participants);
 
-    const ackPayload: GameJoinAckPayload = {
-      current_players: currentPlayers.toString(),
-      max_players: roomInfo.current_participants.toString(),
-      host: hostProfile,
-      players: participants.map((participant) => ({
-        nickname: participant.nickname,
-        profile_image: participant.profile_image,
-        is_ready: participant.is_ready,
-      })),
-    };
+    const players: GamePlayerDto[] = participants.map((participant) => ({
+      nickname: participant.nickname,
+      profile_image: participant.profile_image,
+      is_ready: participant.is_ready,
+    }));
 
-    if (selectedGame) {
-      ackPayload.game = selectedGame;
-    }
+    const ackPayload = new GameJoinAckResponseDto(
+      currentPlayers,
+      roomInfo.current_participants,
+      hostProfile,
+      players,
+      selectedGame,
+    );
 
     // 새로 추가된 경우에만 브로드캐스트
     if (wasAdded) {
@@ -177,13 +157,13 @@ export class GameService {
     return false;
   }
 
-  private async getGameParticipants(roomId: string): Promise<GameParticipant[]> {
+  private async getGameParticipants(roomId: string): Promise<GameParticipantDto[]> {
     const pattern = `room:${roomId}:game:players:*`;
     const keys = await this.redisClient.keys(pattern);
 
     if (!keys.length) return [];
 
-    const participants: GameParticipant[] = [];
+    const participants: GameParticipantDto[] = [];
 
     for (const key of keys) {
       const userId = key.replace(`room:${roomId}:game:players:`, '');
@@ -204,9 +184,9 @@ export class GameService {
 
   private extractHostProfile(
     hostId: string,
-    participants: GameParticipant[],
+    participants: GameParticipantDto[],
     roomParticipants?: Array<{ user_id: string; nickname: string; profile_image: string }>,
-  ): { nickname: string; profile_image: string } {
+  ): GameHostDto {
     const host =
       participants.find((participant) => participant.user_id === hostId) ||
       roomParticipants?.find((participant) => participant.user_id === hostId);
@@ -221,7 +201,7 @@ export class GameService {
     return `room:${roomId}:game`;
   }
 
-  private async getSelectedGame(roomId: string): Promise<GameInfoPayload | undefined> {
+  private async getSelectedGame(roomId: string): Promise<GameInfoPayloadDto | undefined> {
     try {
       const gameKey = this.getGameKey(roomId);
       // 우선 Redis에서 조회
@@ -284,7 +264,7 @@ export class GameService {
     roomId: string,
     userId: string,
     participantCount: number,
-    participants: GameParticipant[],
+    participants: GameParticipantDto[],
   ): Promise<void> {
     const joinedParticipant = participants.find((participant) => participant.user_id === userId);
 

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -84,7 +84,7 @@ export class GameService {
     await this.redisClient.hSet(hostParticipantKey, 'is_ready', '1');
 
     // 해당 방의 모든 참여자에게 브로드캐스트
-    server.to(roomId).emit('game:recruit', {
+    server.to(roomId).emit('game:participant:recruit', {
       is_game_recruiting: true,
     });
 
@@ -212,8 +212,8 @@ export class GameService {
   ): Promise<void> {
     const joinedParticipant = participants.find((participant) => participant.user_id === userId);
 
-    // 방의 다른 모든 사람에게 브로드캐스트 (본인 제외하지 않음, 전체 브로드캐스트)
-    server.to(roomId).emit('game:joined', {
+    // 방의 모든 사람에게 브로드캐스트
+    server.to(roomId).emit('game:participant:join', {
       participant: {
         user_id: joinedParticipant?.user_id || userId,
         nickname: joinedParticipant?.nickname || '',

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -17,6 +17,7 @@ import {
   GamePlayerDto,
   GameReadyBroadcastDto,
   GameStartBroadcastDto,
+  GameCloseBroadcastDto,
 } from './dto/game-response.dto';
 
 @Injectable()
@@ -307,6 +308,47 @@ export class GameService {
 
   private clientStartTimeIso(): string {
     return new Date(Date.now() + this.GAME_START_DELAY_MS).toISOString();
+  }
+
+  /**
+   * 게임 모집 닫기 (방장 전용)
+   */
+  async closeGame(server: Server, roomId: string, userId: string): Promise<void> {
+    // 방 존재 여부 확인
+    const roomExists = await this.roomService.roomExists(roomId);
+    if (!roomExists) {
+      throw new NotFoundException('존재하지 않는 방입니다.');
+    }
+
+    // 사용자가 방에 참여 중인지 확인
+    const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
+    if (!isInRoom) {
+      throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+    }
+
+    // 방장만 게임 모집 닫기 가능
+    const isHost = await this.roomService.isHost(userId, roomId);
+    if (!isHost) {
+      throw new ForbiddenException('방장만 게임 모집을 닫을 수 있습니다.');
+    }
+
+    // Redis에서 게임 모집 상태를 0으로 변경
+    const gameKey = this.getGameKey(roomId);
+    await this.redisClient.hSet(gameKey, 'is_recruiting', '0');
+
+    // 게임 정보 삭제
+    await this.redisClient.del(gameKey);
+    // 참가자 명단 삭제
+    const pattern = `room:${roomId}:game:players:*`;
+    const keys = await this.redisClient.keys(pattern);
+    if (keys.length > 0) {
+      await this.redisClient.del(keys);
+    }
+
+    // 해당 방의 모든 참여자에게 브로드캐스트
+    server.to(roomId).emit('game:participant:close', new GameCloseBroadcastDto(false));
+
+    logMessage(this.logger, LOG.GAME.CLOSE(roomId, userId));
   }
 
   /**

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -18,12 +18,15 @@ import {
   GameReadyBroadcastDto,
   GameStartBroadcastDto,
   GameCloseBroadcastDto,
+  GameRealtimeBroadcastDto,
 } from './dto/game-response.dto';
 
 @Injectable()
 export class GameService {
   private readonly logger = new Logger(GameService.name);
   private readonly GAME_START_DELAY_MS = 3000;
+  private readonly REALTIME_BROADCAST_INTERVAL_MS = 300; // 300ms 주기로 상태 브로드캐스트
+  private realtimeBroadcastTimers: Map<string, NodeJS.Timeout> = new Map(); // 방별 브로드캐스트 타이머
 
   constructor(
     @Inject(forwardRef(() => RoomService)) private readonly roomService: RoomService,
@@ -163,7 +166,7 @@ export class GameService {
       throw new ForbiddenException('게임 모집 중이 아닙니다.');
     }
 
-    // 게임 참가자 명단에 추가
+    // 게임 참가자 명단에 추가. 새로 추가된 경우는 true 반환, 기존에 존재했으면 false 반환
     const wasAdded = await this.addParticipant(roomId, userId);
 
     const [roomInfo, participants, selectedGame] = await Promise.all([
@@ -198,6 +201,27 @@ export class GameService {
     logMessage(this.logger, LOG.GAME.JOIN_REQUEST(roomId, userId));
 
     return ackPayload;
+  }
+
+  private async broadcastGameJoin(
+    server: Server,
+    roomId: string,
+    userId: string,
+    participantCount: number,
+    participants: GameParticipantDto[],
+  ): Promise<void> {
+    const joinedParticipant = participants.find((participant) => participant.user_id === userId);
+
+    // 방의 다른 모든 사람에게 브로드캐스트 (본인 제외하지 않음, 전체 브로드캐스트)
+    server.to(roomId).emit('game:joined', {
+      participant: {
+        user_id: joinedParticipant?.user_id || userId,
+        nickname: joinedParticipant?.nickname || '',
+        profile_image: joinedParticipant?.profile_image || '',
+        is_ready: joinedParticipant?.is_ready ?? false,
+      },
+      participant_count: participantCount.toString(),
+    });
   }
 
   /**
@@ -345,6 +369,9 @@ export class GameService {
       await this.redisClient.del(keys);
     }
 
+    // 실시간 브로드캐스트 타이머 정리
+    this.stopRealtimeBroadcast(roomId);
+
     // 해당 방의 모든 참여자에게 브로드캐스트
     server.to(roomId).emit('game:participant:close', new GameCloseBroadcastDto(false));
 
@@ -468,27 +495,6 @@ export class GameService {
     }
   }
 
-  private async broadcastGameJoin(
-    server: Server,
-    roomId: string,
-    userId: string,
-    participantCount: number,
-    participants: GameParticipantDto[],
-  ): Promise<void> {
-    const joinedParticipant = participants.find((participant) => participant.user_id === userId);
-
-    // 방의 다른 모든 사람에게 브로드캐스트 (본인 제외하지 않음, 전체 브로드캐스트)
-    server.to(roomId).emit('game:joined', {
-      participant: {
-        user_id: joinedParticipant?.user_id || userId,
-        nickname: joinedParticipant?.nickname || '',
-        profile_image: joinedParticipant?.profile_image || '',
-        is_ready: joinedParticipant?.is_ready ?? false,
-      },
-      participant_count: participantCount.toString(),
-    });
-  }
-
   /**
    * 게임 참가자 수 조회
    */
@@ -515,5 +521,180 @@ export class GameService {
     }
 
     return readyCount;
+  }
+
+  /**
+   * 게임 실시간 입력 처리
+   * - 클라이언트의 입력을 누적
+   * - 300ms 주기로 배치하여 모든 사용자에게 상태 브로드캐스트
+   *
+   * @param server Socket.io 서버 인스턴스
+   * @param roomId 방 ID
+   * @param userId 사용자 ID
+   * @param delta 누적된 변경 값
+   */
+  async handleRealtimeInput(server: Server, roomId: string, userId: string, delta: string): Promise<void> {
+    try {
+      // 방 존재 여부 확인
+      const roomExists = await this.roomService.roomExists(roomId);
+      if (!roomExists) {
+        throw new NotFoundException('존재하지 않는 방입니다.');
+      }
+
+      // 사용자가 방에 참여 중인지 확인
+      const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
+      if (!isInRoom) {
+        throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+      }
+
+      // 게임 참가자인지 확인
+      const playerKey = this.getParticipantKey(roomId, userId);
+      const playerExists = await this.redisClient.exists(playerKey);
+      if (!playerExists) {
+        throw new ForbiddenException('게임 참가자가 아닙니다.');
+      }
+
+      // 게임 시작 여부 확인
+      const gameKey = this.getGameKey(roomId);
+      const startTime = await this.redisClient.hGet(gameKey, 'start_time');
+      if (!startTime) {
+        throw new ForbiddenException('게임이 시작되지 않았습니다.');
+      }
+
+      // delta 값 검증
+      const deltaNum = parseInt(delta, 10);
+      if (isNaN(deltaNum) || deltaNum < 0) {
+        throw new Error('Invalid delta value');
+      }
+
+      // 현재 사용자의 점수 업데이트
+      await this.updateParticipantScore(roomId, userId, deltaNum);
+
+      // 300ms 주기 브로드캐스트 스케줄링
+      this.scheduleRealtimeBroadcast(server, roomId);
+
+      logMessage(this.logger, LOG.GAME.REALTIME_INPUT(roomId, userId, delta));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logMessage(this.logger, LOG.GAME.REALTIME_INPUT_ERROR(roomId, userId, errorMessage));
+      throw error;
+    }
+  }
+
+  /**
+   * 참가자 점수 업데이트
+   */
+  private async updateParticipantScore(roomId: string, userId: string, deltaDelta: number): Promise<void> {
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const currentScoreStr = await this.redisClient.hGet(playerKey, 'score');
+    const currentScore = parseInt(currentScoreStr || '0', 10);
+    const newScore = currentScore + deltaDelta;
+
+    await this.redisClient.hSet(playerKey, 'score', newScore.toString());
+  }
+
+  /**
+   * 300ms 주기의 브로드캐스트 스케줄링
+   * - 중복 스케줄링 방지
+   * - 한 번 스케줄되면 주기마다 자동으로 상태 브로드캐스트
+   */
+  private scheduleRealtimeBroadcast(server: Server, roomId: string): void {
+    const timerKey = `realtime:${roomId}`;
+
+    // 이미 스케줄된 경우 추가 스케줄링 하지 않음
+    if (this.realtimeBroadcastTimers.has(timerKey)) {
+      return;
+    }
+
+    // 처음 스케줄링 시 타이머 설정
+    const broadcastTimer = setInterval(async () => {
+      try {
+        await this.broadcastRealtimeState(server, roomId);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        this.logger.error(`브로드캐스트 중 오류: roomId=${roomId}, error=${errorMessage}`);
+      }
+    }, this.REALTIME_BROADCAST_INTERVAL_MS);
+
+    this.realtimeBroadcastTimers.set(timerKey, broadcastTimer);
+  }
+
+  /**
+   * 실시간 게임 상태 브로드캐스트
+   * - 현재 최고 점수
+   * - 평균 점수
+   * - 현재 랭킹 순서
+   */
+  private async broadcastRealtimeState(server: Server, roomId: string): Promise<void> {
+    try {
+      // 모든 참가자 데이터 조회
+      const participants = await this.getGameParticipants(roomId);
+
+      if (participants.length === 0) {
+        // 게임에 참가자가 없으면 브로드캐스트 중지
+        this.stopRealtimeBroadcast(roomId);
+        return;
+      }
+
+      // 점수 기준 정렬 (내림차순)
+      const sortedByScore = [...participants].sort((a, b) => {
+        const scoreA = parseInt(a.score || '0', 10);
+        const scoreB = parseInt(b.score || '0', 10);
+        return scoreB - scoreA;
+      });
+
+      // 최고 점수 계산
+      const highestScore = parseInt(sortedByScore[0]?.score || '0', 10);
+
+      // 평균 점수 계산
+      const totalScore = participants.reduce((sum, p) => sum + parseInt(p.score || '0', 10), 0);
+      const averageScore = (totalScore / participants.length).toFixed(2);
+
+      // 현재 랭킹 순서 (user_id 배열)
+      const ranks = sortedByScore.map((p) => p.user_id);
+
+      // 랭크 업데이트 (Redis에 저장)
+      await this.updateParticipantRanks(roomId, ranks);
+
+      // 브로드캐스트
+      const broadcast: GameRealtimeBroadcastDto = {
+        highest_score: highestScore.toString(),
+        average_score: averageScore,
+        ranks,
+      };
+
+      server.to(roomId).emit('game:participant:realtime', broadcast);
+
+      logMessage(this.logger, LOG.GAME.REALTIME_BROADCAST(roomId, highestScore, averageScore, ranks));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`실시간 상태 브로드캐스트 실패: roomId=${roomId}, error=${errorMessage}`);
+      throw error;
+    }
+  }
+
+  /**
+   * 참가자 랭크 업데이트
+   */
+  private async updateParticipantRanks(roomId: string, ranks: string[]): Promise<void> {
+    for (let i = 0; i < ranks.length; i++) {
+      const userId = ranks[i];
+      const playerKey = this.getParticipantKey(roomId, userId);
+      await this.redisClient.hSet(playerKey, 'rank', (i + 1).toString());
+    }
+  }
+
+  /**
+   * 실시간 브로드캐스트 타이머 중지
+   */
+  public stopRealtimeBroadcast(roomId: string): void {
+    const timerKey = `realtime:${roomId}`;
+    const timer = this.realtimeBroadcastTimers.get(timerKey);
+
+    if (timer) {
+      clearInterval(timer);
+      this.realtimeBroadcastTimers.delete(timerKey);
+      logMessage(this.logger, LOG.GAME.REALTIME_BROADCAST_STOPPED(roomId));
+    }
   }
 }

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -16,11 +16,13 @@ import {
   GameHostDto,
   GamePlayerDto,
   GameReadyBroadcastDto,
+  GameStartBroadcastDto,
 } from './dto/game-response.dto';
 
 @Injectable()
 export class GameService {
   private readonly logger = new Logger(GameService.name);
+  private readonly GAME_START_DELAY_MS = 3000;
 
   constructor(
     @Inject(forwardRef(() => RoomService)) private readonly roomService: RoomService,
@@ -256,6 +258,55 @@ export class GameService {
     server.to(roomId).emit('game:unready', unreadyBroadcast);
 
     logMessage(this.logger, LOG.GAME.UNREADY(roomId, userId));
+  }
+
+  /**
+   * 게임 시작 브로드캐스트 (3초 지연 시작 시간 전달)
+   */
+  async startGame(server: Server, roomId: string, userId: string): Promise<string> {
+    const roomExists = await this.roomService.roomExists(roomId);
+    if (!roomExists) {
+      throw new NotFoundException('존재하지 않는 방입니다.');
+    }
+
+    const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
+    if (!isInRoom) {
+      throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+    }
+
+    const isHost = await this.roomService.isHost(userId, roomId);
+    if (!isHost) {
+      throw new ForbiddenException('방장만 게임을 시작할 수 있습니다.');
+    }
+
+    const selectedGame = await this.getSelectedGame(roomId);
+    if (!selectedGame) {
+      throw new NotFoundException('선택된 게임이 없습니다.');
+    }
+
+    const [readyCount] = await Promise.all([this.getReadyParticipantCount(roomId)]);
+
+    // 최소 인원 이상이어야 게임 시작 가능
+    const minParticipants = parseInt(selectedGame.min_participants, 10);
+    if (!isNaN(minParticipants) && readyCount < minParticipants) {
+      throw new ForbiddenException('게임 최소 인원 조건을 충족하지 못했습니다.');
+    }
+
+    const startTime = this.clientStartTimeIso();
+
+    // 시작 시각 및 모집 상태 캐싱: 더 이상 게임 참가 불가
+    await this.redisClient.hSet(this.getGameKey(roomId), { start_time: startTime, is_recruiting: '0' });
+
+    const broadcast: GameStartBroadcastDto = { start_time: startTime };
+    server.to(roomId).emit('game:start', broadcast);
+
+    logMessage(this.logger, LOG.GAME.START(roomId, userId, startTime));
+
+    return startTime;
+  }
+
+  private clientStartTimeIso(): string {
+    return new Date(Date.now() + this.GAME_START_DELAY_MS).toISOString();
   }
 
   /**

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -236,6 +236,29 @@ export class GameService {
   }
 
   /**
+   * 게임 참가자 준비 해제 처리
+   */
+  async unreadyGame(server: Server, roomId: string, userId: string): Promise<void> {
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const exists = await this.redisClient.exists(playerKey);
+
+    if (!exists) {
+      throw new NotFoundException('게임 참가자 정보를 찾을 수 없습니다.');
+    }
+
+    await this.redisClient.hSet(playerKey, 'is_ready', '0');
+
+    // 준비 해제 브로드캐스트
+    const unreadyBroadcast: GameReadyBroadcastDto = {
+      player_id: userId,
+      is_ready: false,
+    };
+    server.to(roomId).emit('game:unready', unreadyBroadcast);
+
+    logMessage(this.logger, LOG.GAME.UNREADY(roomId, userId));
+  }
+
+  /**
    * 게임 참가 취소
    */
   async leaveGame(roomId: string, userId: string): Promise<void> {

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -66,6 +66,10 @@ export class GameService {
       throw new ForbiddenException('방장만 게임 모집을 시작할 수 있습니다.');
     }
 
+    // Redis에 게임 모집 상태 저장
+    const gameKey = this.getGameKey(roomId);
+    await this.redisClient.hSet(gameKey, 'is_recruiting', '1');
+
     // 방장도 참가자 명단에 추가
     await this.addParticipant(roomId, toUuid(userId));
 
@@ -150,6 +154,12 @@ export class GameService {
     const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
     if (!isInRoom) {
       throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+    }
+
+    // 게임 모집 중인지 확인
+    const isRecruiting = await this.isGameRecruiting(roomId);
+    if (!isRecruiting) {
+      throw new ForbiddenException('게임 모집 중이 아닙니다.');
     }
 
     // 게임 참가자 명단에 추가
@@ -256,6 +266,12 @@ export class GameService {
 
   private getGameKey(roomId: string): string {
     return `room:${roomId}:game`;
+  }
+
+  private async isGameRecruiting(roomId: string): Promise<boolean> {
+    const gameKey = this.getGameKey(roomId);
+    const value = await this.redisClient.hGet(gameKey, 'is_recruiting');
+    return value === '1';
   }
 
   private async getSelectedGame(roomId: string): Promise<GameInfoPayloadDto | undefined> {

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -12,6 +12,7 @@ import {
   GameListResponseDto,
   GameParticipantDto,
   GameInfoPayloadDto,
+  GameSelectBroadcastDto,
   GameJoinAckResponseDto,
   GameHostDto,
   GamePlayerDto,
@@ -74,6 +75,62 @@ export class GameService {
     });
 
     logMessage(this.logger, LOG.GAME.RECRUIT_STARTED(roomId, userId));
+  }
+
+  /**
+   * 게임 선택 및 브로드캐스트
+   */
+  async selectGame(server: Server, roomId: string, userId: string, gameId: string): Promise<GameInfoPayloadDto> {
+    const uuid = toUuid(userId);
+
+    const roomExists = await this.roomService.roomExists(roomId);
+    if (!roomExists) {
+      throw new NotFoundException('존재하지 않는 방입니다.');
+    }
+
+    const isInRoom = await this.roomService.isUserInRoom(userId, roomId);
+    if (!isInRoom) {
+      throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+    }
+
+    const isHost = await this.roomService.isHost(userId, roomId);
+    if (!isHost) {
+      throw new ForbiddenException('방장만 게임을 선택할 수 있습니다.');
+    }
+
+    // db에서 게임 정보 조회
+    const game = await this.gameRepository.findOne({ where: { id: gameId } });
+    if (!game) {
+      throw new NotFoundException('존재하지 않는 게임입니다.');
+    }
+
+    const broadcastPayload: GameInfoPayloadDto = {
+      id: game.id,
+      title: game.title,
+      description: game.description || '',
+      type: game.type,
+      min_participants: game.min_participants?.toString() || '',
+      max_participants: game.max_participants?.toString() || '',
+    };
+
+    // Redis에 선택된 게임 정보 저장
+    // Redis는 인덱스 시그니처가 있는 단순 객체를 요구하므로 별도 캐시용 DTO 사용
+    const cachePayload = {
+      id: broadcastPayload.id,
+      title: broadcastPayload.title,
+      description: broadcastPayload.description || '',
+      type: broadcastPayload.type,
+      min_participants: broadcastPayload.min_participants,
+      max_participants: broadcastPayload.max_participants,
+    };
+    await this.redisClient.hSet(this.getGameKey(roomId), cachePayload);
+
+    const roomBroadcast: GameSelectBroadcastDto = { game: broadcastPayload };
+    server.to(roomId).emit('game:select', roomBroadcast);
+
+    logMessage(this.logger, LOG.GAME.SELECT(roomId, uuid, gameId));
+
+    return broadcastPayload;
   }
 
   /**
@@ -204,54 +261,22 @@ export class GameService {
   private async getSelectedGame(roomId: string): Promise<GameInfoPayloadDto | undefined> {
     try {
       const gameKey = this.getGameKey(roomId);
-      // 우선 Redis에서 조회
+      // Redis에서 조회만 수행 (selectGame에서 이미 저장됨)
       const gameData = await this.redisClient.hGetAll(gameKey);
       if (!gameData || Object.keys(gameData).length === 0) return undefined;
-
-      // Redis에 id가 없다면 선택된 게임이 없는 것으로 간주 -> undefined
       if (!gameData.id) return undefined;
 
-      // 선택된 게임의 모든 필드가 존재하는지 확인
-      const hasAllFields =
-        Boolean(gameData.title) &&
-        Boolean(gameData.type) &&
-        Boolean(gameData.min_participants) &&
-        Boolean(gameData.max_participants);
-
-      // 모든 필드가 존재하면 선택된 게임 정보 반환
-      if (hasAllFields) {
-        return {
-          id: gameData.id,
-          title: gameData.title,
-          description: gameData.description,
-          type: gameData.type,
-          min_participants: gameData.min_participants,
-          max_participants: gameData.max_participants,
-        };
-      }
-
-      // 캐시 불완전 시 MySQL에서 보강 후 Redis에 다시 저장
-      const dbGame = await this.gameRepository.findOne({ where: { id: gameData.id } });
-      if (!dbGame) return undefined;
-
-      // MySQL에서 조회한 게임 정보를 Redis에 저장
-      await this.redisClient.hSet(gameKey, {
-        id: dbGame.id,
-        title: dbGame.title,
-        description: dbGame.description || '',
-        type: dbGame.type,
-        min_participants: dbGame.min_participants?.toString() || '',
-        max_participants: dbGame.max_participants?.toString() || '',
-      });
-
-      return {
-        id: dbGame.id,
-        title: dbGame.title,
-        description: dbGame.description || '',
-        type: dbGame.type,
-        min_participants: dbGame.min_participants?.toString() || '',
-        max_participants: dbGame.max_participants?.toString() || '',
+      // Redis에 저장된 게임 정보 반환
+      const gamePayload: GameInfoPayloadDto = {
+        id: gameData.id,
+        title: gameData.title,
+        description: gameData.description || '',
+        type: gameData.type,
+        min_participants: gameData.min_participants || '',
+        max_participants: gameData.max_participants || '',
       };
+
+      return gamePayload;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.GAME.GAME_STATE_FETCH_ERROR(roomId, errorMessage));

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -6,7 +6,6 @@ import { RedisClientType } from 'redis';
 import { RoomService } from '@src/modules/room/room.service';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
-import { toUuid } from '@src/common/utils/user-id';
 import { Game } from './game.entity';
 import {
   GameListResponseDto,
@@ -16,6 +15,7 @@ import {
   GameJoinAckResponseDto,
   GameHostDto,
   GamePlayerDto,
+  GameReadyBroadcastDto,
 } from './dto/game-response.dto';
 
 @Injectable()
@@ -71,7 +71,11 @@ export class GameService {
     await this.redisClient.hSet(gameKey, 'is_recruiting', '1');
 
     // 방장도 참가자 명단에 추가
-    await this.addParticipant(roomId, toUuid(userId));
+    await this.addParticipant(roomId, userId);
+
+    // 방장도 게임 준비 완료 상태로 설정
+    const hostParticipantKey = this.getParticipantKey(roomId, userId);
+    await this.redisClient.hSet(hostParticipantKey, 'is_ready', '1');
 
     // 해당 방의 모든 참여자에게 브로드캐스트
     server.to(roomId).emit('game:recruit', {
@@ -85,8 +89,6 @@ export class GameService {
    * 게임 선택 및 브로드캐스트
    */
   async selectGame(server: Server, roomId: string, userId: string, gameId: string): Promise<GameInfoPayloadDto> {
-    const uuid = toUuid(userId);
-
     const roomExists = await this.roomService.roomExists(roomId);
     if (!roomExists) {
       throw new NotFoundException('존재하지 않는 방입니다.');
@@ -132,7 +134,7 @@ export class GameService {
     const roomBroadcast: GameSelectBroadcastDto = { game: broadcastPayload };
     server.to(roomId).emit('game:select', roomBroadcast);
 
-    logMessage(this.logger, LOG.GAME.SELECT(roomId, uuid, gameId));
+    logMessage(this.logger, LOG.GAME.SELECT(roomId, userId, gameId));
 
     return broadcastPayload;
   }
@@ -141,10 +143,6 @@ export class GameService {
    * 게임 참가 처리 및 상태 반환
    */
   async joinGame(server: Server, roomId: string, userId: string): Promise<GameJoinAckResponseDto> {
-    const uuid = toUuid(userId);
-
-    logMessage(this.logger, LOG.GAME.JOIN_REQUEST(roomId, uuid));
-
     // 방 존재 여부
     const isRoomExists = await this.roomService.roomExists(roomId);
     if (!isRoomExists) {
@@ -163,7 +161,7 @@ export class GameService {
     }
 
     // 게임 참가자 명단에 추가
-    const wasAdded = await this.addParticipant(roomId, uuid);
+    const wasAdded = await this.addParticipant(roomId, userId);
 
     const [roomInfo, participants, selectedGame] = await Promise.all([
       this.roomService.getRoom(roomId),
@@ -191,10 +189,48 @@ export class GameService {
 
     // 새로 추가된 경우에만 브로드캐스트
     if (wasAdded) {
-      await this.broadcastGameJoin(server, roomId, uuid, currentPlayers, participants);
+      await this.broadcastGameJoin(server, roomId, userId, currentPlayers, participants);
     }
 
+    logMessage(this.logger, LOG.GAME.JOIN_REQUEST(roomId, userId));
+
     return ackPayload;
+  }
+
+  /**
+   * 게임 참가자 준비 완료 처리
+   */
+  async readyGame(server: Server, roomId: string, userId: string): Promise<void> {
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const exists = await this.redisClient.exists(playerKey);
+
+    if (!exists) {
+      throw new NotFoundException('게임 참가자 정보를 찾을 수 없습니다.');
+    }
+
+    await this.redisClient.hSet(playerKey, 'is_ready', '1');
+
+    // 준비 완료 브로드캐스트
+    const readyBroadcast: GameReadyBroadcastDto = {
+      player_id: userId,
+      is_ready: true,
+    };
+    server.to(roomId).emit('game:ready', readyBroadcast);
+
+    logMessage(this.logger, LOG.GAME.READY(roomId, userId));
+  }
+
+  /**
+   * 게임 참가 취소
+   */
+  async leaveGame(roomId: string, userId: string): Promise<void> {
+    const playerKey = this.getParticipantKey(roomId, userId);
+    const exists = await this.redisClient.exists(playerKey);
+
+    if (exists) {
+      await this.redisClient.del(playerKey);
+      logMessage(this.logger, LOG.GAME.LEAVE(roomId, userId));
+    }
   }
 
   private getParticipantKey(roomId: string, userId: string): string {
@@ -224,6 +260,7 @@ export class GameService {
     return false;
   }
 
+  // 게임 참여자 조회
   private async getGameParticipants(roomId: string): Promise<GameParticipantDto[]> {
     const pattern = `room:${roomId}:game:players:*`;
     const keys = await this.redisClient.keys(pattern);
@@ -321,6 +358,9 @@ export class GameService {
     });
   }
 
+  /**
+   * 게임 참가자 수 조회
+   */
   async getParticipantCount(roomId: string): Promise<number> {
     const pattern = `room:${roomId}:game:players:*`;
     const keys = await this.redisClient.keys(pattern);
@@ -328,16 +368,21 @@ export class GameService {
   }
 
   /**
-   * 게임 참가 취소
+   * 게임 준비 완료한 참가자 수 조회
    */
-  async leaveGame(roomId: string, userId: string): Promise<void> {
-    const uuid = toUuid(userId);
-    const playerKey = this.getParticipantKey(roomId, uuid);
-    const exists = await this.redisClient.exists(playerKey);
+  async getReadyParticipantCount(roomId: string): Promise<number> {
+    const pattern = `room:${roomId}:game:players:*`;
+    const keys = await this.redisClient.keys(pattern);
 
-    if (exists) {
-      await this.redisClient.del(playerKey);
-      logMessage(this.logger, LOG.GAME.LEAVE(roomId, uuid));
+    let readyCount = 0;
+
+    for (const key of keys) {
+      const isReady = await this.redisClient.hGet(key, 'is_ready');
+      if (isReady === '1') {
+        readyCount++;
+      }
     }
+
+    return readyCount;
   }
 }

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -20,6 +20,7 @@ import {
   GameCloseBroadcastDto,
   GameRealtimeBroadcastDto,
 } from './dto/game-response.dto';
+import { WS_EVENTS_GAME } from '@src/common/constants/ws-events.constant';
 
 @Injectable()
 export class GameService {
@@ -84,7 +85,7 @@ export class GameService {
     await this.redisClient.hSet(hostParticipantKey, 'is_ready', '1');
 
     // 해당 방의 모든 참여자에게 브로드캐스트
-    server.to(roomId).emit('game:participant:recruit', {
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_RECRUIT, {
       is_game_recruiting: true,
     });
 
@@ -138,7 +139,7 @@ export class GameService {
     await this.redisClient.hSet(this.getGameKey(roomId), cachePayload);
 
     const roomBroadcast: GameSelectBroadcastDto = { game: broadcastPayload };
-    server.to(roomId).emit('game:participant:select', roomBroadcast);
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_SELECT, roomBroadcast);
 
     logMessage(this.logger, LOG.GAME.SELECT(roomId, userId, gameId));
 
@@ -213,7 +214,7 @@ export class GameService {
     const joinedParticipant = participants.find((participant) => participant.user_id === userId);
 
     // 방의 모든 사람에게 브로드캐스트
-    server.to(roomId).emit('game:participant:join', {
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_JOIN, {
       participant: {
         user_id: joinedParticipant?.user_id || userId,
         nickname: joinedParticipant?.nickname || '',
@@ -257,7 +258,7 @@ export class GameService {
       player_id: userId,
       is_ready: true,
     };
-    server.to(roomId).emit('game:participant:ready', readyBroadcast);
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_READY, readyBroadcast);
 
     logMessage(this.logger, LOG.GAME.READY(roomId, userId));
   }
@@ -280,7 +281,7 @@ export class GameService {
       player_id: userId,
       is_ready: false,
     };
-    server.to(roomId).emit('game:participant:unready', unreadyBroadcast);
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_UNREADY, unreadyBroadcast);
 
     logMessage(this.logger, LOG.GAME.UNREADY(roomId, userId));
   }
@@ -323,7 +324,7 @@ export class GameService {
     await this.redisClient.hSet(this.getGameKey(roomId), { start_time: startTime, is_recruiting: '0' });
 
     const broadcast: GameStartBroadcastDto = { start_time: startTime };
-    server.to(roomId).emit('game:participant:start', broadcast);
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_START, broadcast);
 
     logMessage(this.logger, LOG.GAME.START(roomId, userId, startTime));
 
@@ -373,7 +374,7 @@ export class GameService {
     this.stopRealtimeBroadcast(roomId);
 
     // 해당 방의 모든 참여자에게 브로드캐스트
-    server.to(roomId).emit('game:participant:close', new GameCloseBroadcastDto(false));
+    server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_CLOSE, new GameCloseBroadcastDto(false));
 
     logMessage(this.logger, LOG.GAME.CLOSE(roomId, userId));
   }
@@ -663,7 +664,7 @@ export class GameService {
         ranks,
       };
 
-      server.to(roomId).emit('game:participant:realtime', broadcast);
+      server.to(roomId).emit(WS_EVENTS_GAME.PARTICIPANT_REALTIME, broadcast);
 
       logMessage(this.logger, LOG.GAME.REALTIME_BROADCAST(roomId, highestScore, averageScore, ranks));
     } catch (error) {

--- a/be/src/modules/game/game.service.ts
+++ b/be/src/modules/game/game.service.ts
@@ -208,6 +208,21 @@ export class GameService {
       throw new NotFoundException('게임 참가자 정보를 찾을 수 없습니다.');
     }
 
+    // 선택된 게임 정보 조회
+    const selectedGame = await this.getSelectedGame(roomId);
+    if (selectedGame) {
+      const maxParticipants = parseInt(selectedGame.max_participants, 10);
+      if (!isNaN(maxParticipants)) {
+        // 현재 준비 완료한 참가자 수 조회 (본인 포함 전)
+        const currentReadyCount = await this.getReadyParticipantCount(roomId);
+
+        // 본인이 준비 완료하면 최대 인원을 초과하는지 확인
+        if (currentReadyCount + 1 > maxParticipants) {
+          throw new ForbiddenException('게임 최대 인원을 초과할 수 없습니다.');
+        }
+      }
+    }
+
     await this.redisClient.hSet(playerKey, 'is_ready', '1');
 
     // 준비 완료 브로드캐스트

--- a/be/src/modules/room/dto/room-response.dto.ts
+++ b/be/src/modules/room/dto/room-response.dto.ts
@@ -1,0 +1,68 @@
+export class ParticipantDto {
+  user_id: string;
+  nickname: string;
+  profile_image: string;
+}
+
+export class ParticipantDetailDto {
+  user_id: string;
+  nickname: string;
+  profile_image: string;
+  role: string;
+  is_mic_on: boolean;
+  is_audio_on: boolean;
+  is_speaking: boolean;
+  join_date: Date;
+}
+
+export class RoomReadResponseDto {
+  id: string;
+  title: string;
+  tags: string[];
+  host_id: string;
+  current_participants: number;
+  max_participants: number;
+  is_mic_available: boolean;
+  is_private: boolean;
+  participants: ParticipantDto[];
+  create_date: Date;
+}
+
+export class RoomListResponseDto {
+  rooms: RoomReadResponseDto[];
+}
+
+export class RoomCreateResponseDto {
+  id: string;
+  title: string;
+  tags: string[];
+  host_id: string;
+  current_participants: number;
+  max_participants: number;
+  participants: ParticipantDetailDto[];
+  is_mic_available: boolean;
+  is_private: boolean;
+  create_date: Date;
+}
+
+export class RoomDeleteResponseDto {
+  id: string;
+}
+
+export class RoomJoinInfoResponseDto {
+  id: string;
+  title: string;
+  tags: string[];
+  is_mic_available: boolean;
+  is_private: boolean;
+  is_member: boolean;
+}
+
+export class GlobalChatRecentMessageDto {
+  sender_id: string;
+  content: string;
+  nickname: string;
+  profile_image: string;
+  role: string;
+  create_date: string;
+}

--- a/be/src/modules/room/dto/room.dto.ts
+++ b/be/src/modules/room/dto/room.dto.ts
@@ -1,14 +1,4 @@
-import {
-  IsArray,
-  IsBoolean,
-  IsDate,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
 /**
  * REST API 방 입장 요청 DTO (Body)
@@ -38,48 +28,6 @@ export class RoomLeaveDto {
 /**
  * 참여자 정보 DTO
  */
-export class ParticipantDto {
-  @IsString()
-  @IsNotEmpty()
-  user_id: string;
-
-  @IsString()
-  nickname: string;
-
-  @IsString()
-  profile_image: string;
-}
-
-/**
- * 참여자 상세 정보 DTO
- */
-export class ParticipantDetailDto {
-  @IsString()
-  @IsNotEmpty()
-  user_id: string;
-
-  @IsString()
-  nickname: string;
-
-  @IsString()
-  profile_image: string;
-
-  @IsString()
-  role: string;
-
-  @IsBoolean()
-  is_mic_on: boolean;
-
-  @IsBoolean()
-  is_audio_on: boolean;
-
-  @IsBoolean()
-  is_speaking: boolean;
-
-  @IsDate()
-  join_date: Date;
-}
-
 /**
  * 방 생성 요청 DTO
  */
@@ -106,152 +54,10 @@ export class RoomRequestDto {
 }
 
 /**
- * 방 목록 조회 응답 DTO (각 방 항목)
- */
-export class RoomReadResponseDto {
-  @IsString()
-  id: string;
-
-  @IsString()
-  title: string;
-
-  @IsArray()
-  @IsString({ each: true })
-  tags: string[];
-
-  @IsString()
-  host_id: string;
-
-  @IsNumber()
-  current_participants: number;
-
-  @IsNumber()
-  max_participants: number;
-
-  @IsBoolean()
-  is_mic_available: boolean;
-
-  @IsBoolean()
-  is_private: boolean;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => ParticipantDto)
-  participants: ParticipantDto[];
-
-  @IsDate()
-  @Type(() => Date)
-  create_date: Date;
-}
-
-/**
- * 방 목록 응답 DTO
- */
-export class RoomListResponseDto {
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => RoomReadResponseDto)
-  rooms: RoomReadResponseDto[];
-}
-
-/**
- * 방 생성 응답 DTO
- */
-export class RoomCreateResponseDto {
-  @IsString()
-  id: string;
-
-  @IsString()
-  title: string;
-
-  @IsArray()
-  @IsString({ each: true })
-  tags: string[];
-
-  @IsString()
-  host_id: string;
-
-  @IsNumber()
-  current_participants: number;
-
-  @IsNumber()
-  max_participants: number;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => ParticipantDetailDto)
-  participants: ParticipantDetailDto[];
-
-  @IsBoolean()
-  is_mic_available: boolean;
-
-  @IsBoolean()
-  is_private: boolean;
-
-  @IsDate()
-  create_date: Date;
-}
-
-/**
- * 방 삭제 응답 DTO
- */
-export class RoomDeleteResponseDto {
-  @IsString()
-  id: string;
-}
-
-/**
  * 방 검색 조회 시 사용하는 DTO
  */
 export class RoomSearchQueryDto {
   @IsString()
   @IsOptional()
   keyword?: string;
-}
-
-/**
- * 방 입장 정보 응답 DTO
- */
-export class RoomJoinInfoResponseDto {
-  @IsString()
-  id: string;
-
-  @IsString()
-  title: string;
-
-  @IsArray()
-  @IsString({ each: true })
-  tags: string[];
-
-  @IsBoolean()
-  is_mic_available: boolean;
-
-  @IsBoolean()
-  is_private: boolean;
-
-  @IsBoolean()
-  is_member: boolean;
-}
-
-/**
- * 글로벌 채팅 최신 메시지 DTO
- */
-export class GlobalChatRecentMessageDto {
-  @IsString()
-  sender_id: string;
-
-  @IsString()
-  content: string;
-
-  @IsString()
-  nickname: string;
-
-  @IsString()
-  profile_image: string;
-
-  @IsString()
-  role: string;
-
-  @IsString()
-  create_date: string;
 }

--- a/be/src/modules/room/room.controller.ts
+++ b/be/src/modules/room/room.controller.ts
@@ -13,17 +13,14 @@ import {
   UseGuards,
   Req,
 } from '@nestjs/common';
+import { RoomRequestDto, JoinRoomRequestDto, RoomJoinDto, RoomSearchQueryDto } from './dto/room.dto';
 import {
-  RoomRequestDto,
   RoomCreateResponseDto,
   RoomDeleteResponseDto,
-  JoinRoomRequestDto,
-  RoomJoinDto,
   RoomListResponseDto,
-  RoomSearchQueryDto,
   RoomReadResponseDto,
   RoomJoinInfoResponseDto,
-} from './dto/room.dto';
+} from './dto/room-response.dto';
 import { RoomService } from './room.service';
 import { ApiResponseMessage } from '@src/common/decorators/api-response-message.decorator';
 import { AuthGuard } from '@src/modules/auth/auth.guard';

--- a/be/src/modules/room/room.gateway.ts
+++ b/be/src/modules/room/room.gateway.ts
@@ -89,8 +89,7 @@ export class RoomGateway {
         // Redis에는 참여 중이지만 Socket.io room에 참여하지 않았을 수 있으므로 재참여만
         client.join(dto.room_id);
         const currentParticipants = await this.roomService.getCurrentParticipants(dto.room_id);
-        client.emit('room:join', { roomId: dto.room_id, current_participants: currentParticipants });
-        return;
+        return { roomId: dto.room_id, current_participants: currentParticipants };
       }
 
       // 정원 확인
@@ -117,9 +116,6 @@ export class RoomGateway {
       // Socket.io room에 참여
       client.join(dto.room_id);
 
-      // 클라이언트에 입장 성공 알림 (ACK, 참여자 수 포함)
-      client.emit('room:join', { roomId: dto.room_id, current_participants: currentParticipants });
-
       // 브로드캐스트: 사용자 정보 및 현재 참여자 수 조회
       // Service를 통해 MySQL에서 사용자 정보 조회
       const user = await this.authService.getUserById(userId);
@@ -140,6 +136,9 @@ export class RoomGateway {
       );
 
       logMessage(this.logger, LOG.ROOM.JOIN(userId, dto.room_id));
+
+      // 클라이언트에 입장 성공 알림 (ACK, 참여자 수 포함)
+      return { roomId: dto.room_id, current_participants: currentParticipants };
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -185,10 +184,9 @@ export class RoomGateway {
       // 공통 퇴장 처리
       await this.leaveRoomProcess(client, userId, dto.room_id);
 
-      // 클라이언트에 퇴장 성공 알림 (ACK)
-      client.emit('room:leave', { roomId: dto.room_id });
-
       logMessage(this.logger, LOG.ROOM.LEAVE(userId, dto.room_id));
+      // 클라이언트에 퇴장 성공 알림 (ACK)
+      return { roomId: dto.room_id };
     } catch (error) {
       // 모든 예외를 일관되게 처리
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/be/src/modules/room/room.gateway.ts
+++ b/be/src/modules/room/room.gateway.ts
@@ -11,6 +11,7 @@ import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GLOBAL_ROOM_ID } from '@src/common/constants/constants';
 import { createWsError, createWsErrorResponse } from '@src/common/utils/ws-error-code';
+import { WS_EVENTS_ROOM, WS_EVENTS_ERROR } from '@src/common/constants/ws-events.constant';
 
 @UseFilters(new WsExceptionFilter())
 @WebSocketGateway({ namespace: '/' })
@@ -42,7 +43,7 @@ export class RoomGateway {
    * 대화방 입장 처리 (로컬)
    * 요구사항: 권한 검증 후 논리적 상태 변경 및 Socket.io room 참여
    */
-  @SubscribeMessage('room:join')
+  @SubscribeMessage(WS_EVENTS_ROOM.JOIN)
   async handleRoomJoin(@ConnectedSocket() client: Socket, @MessageBody() dto: RoomJoinDto) {
     // 디버깅: 받은 데이터 로그
     logMessage(this.logger, LOG.WS.ROOM_JOIN_DTO_RECEIVED(JSON.stringify(dto), typeof dto));
@@ -58,7 +59,7 @@ export class RoomGateway {
     // 인증 확인
     if (!isAuthenticated || !userId) {
       logMessage(this.logger, LOG.ROOM.UNAUTH_JOIN(client.id));
-      client.emit('error', createWsError('UNAUTHORIZED', '로그인이 필요합니다.'));
+      client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '로그인이 필요합니다.'));
       return;
     }
 
@@ -69,7 +70,7 @@ export class RoomGateway {
       // 방 존재 여부 및 타입 확인
       if (roomType === null) {
         logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.room_id));
-        client.emit('error', createWsError('NOT_FOUND', '존재하지 않는 방입니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('NOT_FOUND', '존재하지 않는 방입니다.'));
         return;
       }
 
@@ -77,7 +78,7 @@ export class RoomGateway {
       const canJoin = await this.roomService.canUserJoinRoom(userId, dto.room_id);
       if (!canJoin) {
         logMessage(this.logger, LOG.ROOM.NO_PERMISSION(userId, dto.room_id));
-        client.emit('error', createWsError('FORBIDDEN', '방 입장 권한이 없습니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('FORBIDDEN', '방 입장 권한이 없습니다.'));
         return;
       }
 
@@ -98,7 +99,7 @@ export class RoomGateway {
 
       if (maxParticipants > 0 && currentParticipants >= maxParticipants) {
         logMessage(this.logger, LOG.ROOM.VALIDATION_ERROR(userId, dto.room_id, '방 정원 초과'));
-        client.emit('error', createWsError('FORBIDDEN', '방 정원이 초과되었습니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('FORBIDDEN', '방 정원이 초과되었습니다.'));
         return;
       }
 
@@ -147,7 +148,7 @@ export class RoomGateway {
 
       const errorResponse = createWsErrorResponse(error, '방 입장 처리 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         // emit 실패 시 무시
@@ -160,7 +161,7 @@ export class RoomGateway {
    * 방 퇴장 처리
    * 요구사항: 논리적 상태 변경 및 Socket.io room에서 제거
    */
-  @SubscribeMessage('room:leave')
+  @SubscribeMessage(WS_EVENTS_ROOM.LEAVE)
   async handleRoomLeave(@ConnectedSocket() client: Socket, @MessageBody() dto: RoomLeaveDto) {
     try {
       const userId = client.data.userId;
@@ -169,7 +170,7 @@ export class RoomGateway {
       // 권한 검증: 인증되지 않은 사용자는 방 퇴장 불가능
       if (!isAuthenticated || !userId) {
         logMessage(this.logger, LOG.ROOM.UNAUTH_LEAVE(client.id));
-        client.emit('error', createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('UNAUTHORIZED', '인증이 필요합니다.'));
         return;
       }
 
@@ -177,7 +178,7 @@ export class RoomGateway {
       const isInRoom = await this.roomService.isUserInRoom(userId, dto.room_id);
       if (!isInRoom) {
         logMessage(this.logger, LOG.ROOM.NOT_IN(userId, dto.room_id));
-        client.emit('error', createWsError('NOT_FOUND', '해당 방에 참여하지 않았습니다.'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('NOT_FOUND', '해당 방에 참여하지 않았습니다.'));
         return;
       }
 
@@ -195,7 +196,7 @@ export class RoomGateway {
 
       const errorResponse = createWsErrorResponse(error, '방 퇴장 처리 중 문제가 발생했습니다.');
       try {
-        client.emit('error', errorResponse);
+        client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
         return;
       } catch (emitError) {
         this.logger.warn('에러 메시지 전송 실패', emitError);

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -18,8 +18,8 @@ import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { UUID } from 'crypto';
 import { User } from '@src/modules/user/user.entity';
+import { RoomRequestDto } from './dto/room.dto';
 import {
-  RoomRequestDto,
   RoomCreateResponseDto,
   RoomReadResponseDto,
   RoomDeleteResponseDto,
@@ -28,7 +28,7 @@ import {
   RoomListResponseDto,
   RoomJoinInfoResponseDto,
   GlobalChatRecentMessageDto,
-} from './dto/room.dto';
+} from './dto/room-response.dto';
 import { toUuid } from '@src/common/utils/user-id';
 import { ROOM_TYPE, RoomType } from './room.type';
 import { Server } from 'socket.io';

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -711,7 +711,7 @@ export class RoomService implements OnModuleInit {
     // Redis adapter를 사용하는 경우 server.to()가 모든 서버 인스턴스에 브로드캐스트를 전파
     // fetchSockets()는 현재 서버 인스턴스의 클라이언트만 반환할 수 있으므로
     // server.to()를 사용하여 모든 클라이언트에게 브로드캐스트 전송
-    server.to(roomId).emit('room:joined', data);
+    server.to(roomId).emit('room:participant:join', data);
     logMessage(this.logger, LOG.CHAT.BROADCAST_SENT(roomId, 'notifyUserJoined', userInfo.userId, roomClientsCount));
   }
   /**
@@ -732,7 +732,7 @@ export class RoomService implements OnModuleInit {
     // Redis adapter를 사용하는 경우 server.to()가 모든 서버 인스턴스에 브로드캐스트를 전파
     // fetchSockets()는 현재 서버 인스턴스의 클라이언트만 반환할 수 있으므로
     // server.to()를 사용하여 모든 클라이언트에게 브로드캐스트 전송
-    server.to(roomId).emit('room:left', data);
+    server.to(roomId).emit('room:participant:leave', data);
     logMessage(this.logger, LOG.CHAT.BROADCAST_SENT(roomId, 'notifyUserLeft', userId, roomClientsCount));
     logMessage(this.logger, LOG.CHAT.USER_LEFT(roomId, userId));
   }

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -18,6 +18,7 @@ import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { UUID } from 'crypto';
 import { User } from '@src/modules/user/user.entity';
+import { WS_EVENTS_ROOM, WS_EVENTS_CHAT } from '@src/common/constants/ws-events.constant';
 import { RoomRequestDto } from './dto/room.dto';
 import {
   RoomCreateResponseDto,
@@ -711,7 +712,7 @@ export class RoomService implements OnModuleInit {
     // Redis adapter를 사용하는 경우 server.to()가 모든 서버 인스턴스에 브로드캐스트를 전파
     // fetchSockets()는 현재 서버 인스턴스의 클라이언트만 반환할 수 있으므로
     // server.to()를 사용하여 모든 클라이언트에게 브로드캐스트 전송
-    server.to(roomId).emit('room:participant:join', data);
+    server.to(roomId).emit(WS_EVENTS_ROOM.PARTICIPANT_JOIN, data);
     logMessage(this.logger, LOG.CHAT.BROADCAST_SENT(roomId, 'notifyUserJoined', userInfo.userId, roomClientsCount));
   }
   /**
@@ -732,7 +733,7 @@ export class RoomService implements OnModuleInit {
     // Redis adapter를 사용하는 경우 server.to()가 모든 서버 인스턴스에 브로드캐스트를 전파
     // fetchSockets()는 현재 서버 인스턴스의 클라이언트만 반환할 수 있으므로
     // server.to()를 사용하여 모든 클라이언트에게 브로드캐스트 전송
-    server.to(roomId).emit('room:participant:leave', data);
+    server.to(roomId).emit(WS_EVENTS_ROOM.PARTICIPANT_LEAVE, data);
     logMessage(this.logger, LOG.CHAT.BROADCAST_SENT(roomId, 'notifyUserLeft', userId, roomClientsCount));
     logMessage(this.logger, LOG.CHAT.USER_LEFT(roomId, userId));
   }
@@ -744,7 +745,7 @@ export class RoomService implements OnModuleInit {
     const data = { roomId, current_participants: currentParticipants };
 
     // 글로벌 방의 경우 모든 클라이언트에게 브로드캐스트
-    server.emit('chat:global:participants-updated', data);
+    server.emit(WS_EVENTS_CHAT.GLOBAL_PARTICIPANTS_UPDATED, data);
     logMessage(this.logger, LOG.CHAT.PARTICIPANTS_UPDATED(roomId, currentParticipants));
   }
 

--- a/fe/.gitignore
+++ b/fe/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# docs
+docs

--- a/fe/src/app/features/chat/components/GlobalChatPanel.tsx
+++ b/fe/src/app/features/chat/components/GlobalChatPanel.tsx
@@ -36,16 +36,16 @@ export default function GlobalChatPanel() {
     const subscribe = async () => {
       await globalChatService.subscribe();
 
-      const savedMessages = globalChatService.getMessages();
-      if (savedMessages.length > 0) setChats(savedMessages);
-
       // 구독 완료 후 연결 상태 확인
       setIsConnected(globalChatService.isConnected());
     };
 
     subscribe();
 
-    // 메시지 수신 콜백 등록
+    // recents 수신 콜백 등록 (초기 메시지 로드 시 배열 교체)
+    const unsubscribeRecents = globalChatService.onRecents((messages) => setChats(messages));
+
+    // 메시지 수신 콜백 등록 (새 메시지만 추가)
     const unsubscribeMessage = globalChatService.onMessage((message) =>
       setChats((prev) => [...prev, message]),
     );
@@ -62,6 +62,7 @@ export default function GlobalChatPanel() {
 
     // 정리 함수
     return () => {
+      unsubscribeRecents();
       unsubscribeMessage();
       unsubscribeConnection();
       unsubscribeParticipants();

--- a/fe/src/app/features/chat/services/GlobalChatService.ts
+++ b/fe/src/app/features/chat/services/GlobalChatService.ts
@@ -7,6 +7,7 @@ import {
   MessageCallback,
   ConnectionCallback,
   ParticipantsCallback,
+  RecentsCallback,
   WebSocketErrorDto,
   ParticipantsUpdatedDto,
   GlobalChatRecentsDto,
@@ -23,6 +24,7 @@ export class GlobalChatService implements ChatChannel {
   private messageCallbacks: Set<MessageCallback> = new Set();
   private connectionCallbacks: Set<ConnectionCallback> = new Set();
   private participantsCallbacks: Set<ParticipantsCallback> = new Set();
+  private recentsCallbacks: Set<RecentsCallback> = new Set();
   private isSubscribed = false;
   private messages: ChatReceiveData[] = [];
   private eventHandlers: Map<string, (...args: any[]) => void> = new Map();
@@ -117,11 +119,11 @@ export class GlobalChatService implements ChatChannel {
   private handleGlobalChatRecents(dto: GlobalChatRecentsDto): void {
     this.messages = [];
 
-    dto.messages.forEach((msg) => {
-      const chatData = ChatConverter.toReceiveData(msg);
-      this.messages.push(chatData);
-      this.notifyMessage(chatData);
-    });
+    const chatMessages = dto.messages.map((msg) => ChatConverter.toReceiveData(msg));
+    this.messages = chatMessages;
+
+    // recents는 일괄 업데이트 콜백으로 전달 (개별 메시지 콜백 호출 X)
+    this.notifyRecents(chatMessages);
 
     if (dto.current_participants != null) this.notifyParticipants(dto.current_participants);
   }
@@ -165,6 +167,11 @@ export class GlobalChatService implements ChatChannel {
     return () => this.participantsCallbacks.delete(callback);
   }
 
+  onRecents(callback: RecentsCallback): () => void {
+    this.recentsCallbacks.add(callback);
+    return () => this.recentsCallbacks.delete(callback);
+  }
+
   isConnected(): boolean {
     return WebSocketService.isConnected();
   }
@@ -183,6 +190,10 @@ export class GlobalChatService implements ChatChannel {
 
   private notifyParticipants(count: number): void {
     this.participantsCallbacks.forEach((callback) => callback(count));
+  }
+
+  private notifyRecents(messages: ChatReceiveData[]): void {
+    this.recentsCallbacks.forEach((callback) => callback(messages));
   }
 }
 

--- a/fe/src/app/features/chat/services/type.ts
+++ b/fe/src/app/features/chat/services/type.ts
@@ -10,6 +10,7 @@ import { ChatReceiveData, ChatReceiveDto } from '@/app/features/chat/dtos/type';
 export type MessageCallback = (message: ChatReceiveData) => void;
 export type ConnectionCallback = (isConnected: boolean) => void;
 export type ParticipantsCallback = (count: number) => void;
+export type RecentsCallback = (messages: ChatReceiveData[]) => void;
 
 // WebSocket 에러 DTO
 export interface WebSocketErrorDto {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

# 완료

- ✅ 게임 **참여** 시 선택된 게임 가져오는 로직 검토 및 수정
    - 게임 **선택** 시에는 db를 통해서 가져오고, 그걸 redis에 캐시해놓음. 이후 사용자가 **참여**했을 때 보내주는 game 정보(`getSelectedGame`)는 redis에서 가져옴
    - 🤔 만약 db의 게임 정보가 바뀌면?
        1. TTL을 통해서 redis에 저장할 때 expire time을 설정하기
        2. 혹은 가능하다면 게임 정보 수정 시 Redis 캐시 invalidate되게 하기
        
        → 그러나 게임의 정보가 잘 바뀌지 않을 가능성이 높고, 게임 선택 시 db를 통하기 때문에 최신 데이터일 확률이 놓음. **논의해봐야 함.**
        
- ✅ 게임 **모집**: 방장이 게임을 모집한 이후 게임 참여가 가능하도록 로직 보완
    1. **`startGameRecruiting`에서 Redis에 `is_game_recruiting` 상태 저장**
        
        ```bash
        # Game
        room:{roomId}:game
          - id
          - title
          - type
          - description
          - max_participants
          - min_participants
          - is_recruiting (게임 모집 시 추가됨)
        ```
        
    2. **`joinGame`에서 게임 모집 중인지 검증 추가**
- ✅ 응답 페이로드를 따로 class로 정의하기 - response dto
- ✅ 글로벌 채팅 중복 메세지 이슈 해결
- ✅ 이벤트명 상수화
- ✅ API 명세 변경사항 적용 및 ACK 콜백 응답 형식 수정


# API 구현

- 게임 선택
    - 방장이 게임 **선택** 시 Redis에 게임 정보 저장
        - `room:{roomId}:game` Hash에 `id`, `title`, `type`, `description`, `max_participants`, `min_participants` 저장
- 게임 준비 완료
    
    ```bash
    # Game Players
    room:{roomId}:game:players:{userId}
      - nickname
      - profile_image
      - is_ready
      - score
      - rank
    ```
    
    - 방장은 모집 시 자동으로 **참여** 및 **준비 완료** 되도록 함
    - `현재 준비 완료한 참여자의 수` < `게임의 max_participants` 일때만 준비 완료 가능
        - ‘게임 최대 인원을 초과할 수 없습니다.’ `error` 이벤트 전송
- 게임 준비 해제
- 게임 시작
    - 게임 시작 시 `start_time`을 Redis에 저장하면서 `is_recruiting`을 `0`으로 내려 게임 모집을 닫음
        - 그럼 게임 시작 이후 `game:join`은 `is_recruiting` 체크에서 걸려 ‘게임 모집 중이 아닙니다.’ 에러를 반환하므로, 게임 진행 중에는 새 참여가 블로킹 됨
- 게임 닫기
    - 게임 정보 및 참가자 명단 삭제
    - `is_recruiting` 을 `0` 으로 변경
- 실시간 게임 정보 전달
    - 참가인원이 0명이거나 방장이 게임을 닫으면 브로드캐스팅 스케쥴링 중단시킴
    - `private realtimeBroadcastTimers: Map<string, NodeJS.Timeout> = new Map();`
        - 방별 브로드캐스트 타이머를 인메모리식으로 관리해도 되는건지 확인 필요

# TODO

- toUuid 사용하는곳 삭제 - 유틸 함수는 존재해야함 (mock auth에서 사용)
- game 플로우차트 작성 → 개발 완료 후
---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- close #159
- close #160
- close #161 
- close #163 
- close #164 
- in_progress #165 

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [글로벌 채팅 메세지 중복 노출 이슈 해결](https://rapid-bubble-113.notion.site/2ee207f2334180e6b251c2184f9395a9?source=copy_link)
