### PR TITLE
[Feat] websocket service 에 request() 추가 + webRTC service, VoiceService 추가

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.19",
+    "mediasoup-client": "^3.18.3",
     "next": "^14.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/fe/src/app/features/voice/services/VoiceService.ts
+++ b/fe/src/app/features/voice/services/VoiceService.ts
@@ -1,0 +1,311 @@
+import { WebSocketService } from '@/app/services/websocket.service';
+import { WebRtcService } from '@/app/services/webRTC.service';
+import { Producer, Consumer } from 'mediasoup-client/types';
+
+type VoiceStatusPayload = {
+  userId: string;
+  isMicOn: boolean;
+  stream?: MediaStream;
+  action: 'add' | 'remove' | 'update';
+};
+
+export class VoiceService {
+  private static isInitialized = false;
+  private static webRtc = new WebRtcService();
+  private static roomId: string | null = null;
+
+  private static myProducer: Producer | null = null;
+  private static consumers: Map<string, Consumer> = new Map(); // Key: remoteProducerId
+
+  private static statusListeners: Set<(payload: VoiceStatusPayload) => void> = new Set();
+
+  private static init() {
+    if (this.isInitialized) return;
+
+    WebSocketService.on('voice:new-producer', (data) => this.handleNewProducer(data));
+    WebSocketService.on('voice:producer:update', (data) => this.handleProducerUpdate(data));
+    WebSocketService.on('voice:producer:closed', (data) => this.handleProducerClosed(data));
+
+    this.isInitialized = true;
+  }
+
+  // 구독 메서드
+  static onStatusChange(callback: (payload: VoiceStatusPayload) => void) {
+    this.statusListeners.add(callback);
+    return () => this.statusListeners.delete(callback);
+  }
+
+  // 내부 알림 메서드
+  private static notify(payload: VoiceStatusPayload) {
+    this.statusListeners.forEach((cb) => cb(payload));
+  }
+
+  /**
+   * 1. 음성 채널 입장 및 초기화
+   */
+  static async joinVoiceChannel(roomId: string) {
+    this.init();
+    this.roomId = roomId;
+
+    try {
+      // (1) Router Capabilities 조회
+      const routerCaps = await this.request('voice:router:capabilities', { room_id: roomId });
+
+      // (2) WebRTC 디바이스 초기화 (코덱 맞추기)
+      await this.webRtc.initDevice(routerCaps);
+
+      // (3) 송출용(Send) Transport 생성
+      await this.setupTransport(roomId, true);
+
+      // (4) 수신용(Recv) Transport 생성
+      await this.setupTransport(roomId, false);
+
+      // (5) 서버의 기존 참여자들 확인을 위한 리스너 등록은 WebSocketService에서 처리
+      console.log('음성 채널 연결 준비 완료');
+    } catch (error) {
+      console.error('채널 입장 실패:', error);
+    }
+  }
+
+  /**
+   * 2. Transport 설정 (핵심 연결 로직)
+   */
+  private static async setupTransport(roomId: string, producing: boolean) {
+    // A. 서버에 Transport 생성 요청
+    const transportOptions = await this.request('voice:transport:create', {
+      room_id: roomId,
+      producing,
+    });
+
+    // B. 엔진에 Transport 객체 생성 위임
+    const direction = producing ? 'send' : 'recv';
+    const transport = this.webRtc.createTransport(direction, transportOptions);
+
+    // C. [이벤트] 연결 시작 (Handshake)
+    transport.on('connect', async ({ dtlsParameters }, callback, errback) => {
+      try {
+        await this.request('voice:transport:connect', {
+          room_id: roomId,
+          transport_id: transport.id,
+          dtls_parameters: dtlsParameters,
+        });
+        callback();
+      } catch (err: any) {
+        errback(err);
+      }
+    });
+
+    // D. [이벤트] (송출용 전용) 실제 데이터 스트림 생성
+    if (producing) {
+      transport.on('produce', async ({ kind, rtpParameters }, callback, errback) => {
+        try {
+          const data = await this.request('voice:producer:create', {
+            room_id: roomId,
+            transport_id: transport.id,
+            kind,
+            rtp_parameters: rtpParameters,
+          });
+          callback({ id: data.id });
+        } catch (err: any) {
+          errback(err);
+        }
+      });
+    }
+  }
+
+  /**
+   * 3. 내 마이크 켜기 (Producer 생성)
+   */
+  static async startMic() {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const track = stream.getAudioTracks()[0];
+
+      this.myProducer = await this.webRtc.produceAudio(track);
+
+      // 마이크 끄기 대비 (track 종료 이벤트)
+      this.myProducer.on('trackended', () => {
+        this.stopMic();
+      });
+    } catch (error) {
+      console.error('마이크 시작 실패:', error);
+    }
+  }
+
+  static async stopMic() {
+    if (!this.myProducer) return;
+    await this.request('voice:producer:close', {
+      room_id: this.roomId,
+      producer_id: this.myProducer.id,
+    });
+    this.myProducer.close();
+    this.myProducer = null;
+  }
+
+  /**
+   * 4. 상대방 소리 듣기 (Consumer 생성)
+   */
+  static async consumeUser(remoteUserId: string, remoteProducerId: string) {
+    try {
+      const recvTransportId = this.webRtc.recvTransportId;
+
+      if (!recvTransportId) {
+        throw new Error('수신용 트랜스포트가 준비되지 않았습니다.');
+      }
+
+      const consumerOptions = await this.request('voice:consumer:create', {
+        transport_id: recvTransportId,
+        producer_id: remoteProducerId,
+        rtp_capabilities: this.webRtc.rtpCapabilities, // 내 사양 전달
+      });
+
+      const consumer = await this.webRtc.consumeAudio({
+        ...consumerOptions,
+        appData: { userId: remoteUserId }, //유저 구분 용
+      });
+
+      this.consumers.set(remoteProducerId, consumer);
+
+      // 명세에 따라 수신 재개 요청
+      await this.request('voice:consumer:resume', { consumer_id: consumer.id });
+
+      // 실제 오디오 재생 로직 (예: 오디오 태그 연결)
+      const stream = new MediaStream([consumer.track]);
+      return stream;
+    } catch (error) {
+      console.error('소리 수신 실패:', error);
+    }
+  }
+
+  /**
+   * 5. 마이크 상태 제어 (Pause/Resume)
+   */
+  static async toggleMic(pause: boolean) {
+    if (!this.myProducer) return;
+
+    const event = pause ? 'voice:producer:pause' : 'voice:producer:resume';
+    await this.request(event, { producer_id: this.myProducer.id });
+
+    if (pause) this.myProducer.pause();
+    else this.myProducer.resume();
+  }
+
+  /**
+   * 6. 특정 유저의 소리 수신 상태 제어 (Pause/Resume)
+   */
+  static async toggleConsumer(remoteProducerId: string, pause: boolean) {
+    const consumer = this.consumers.get(remoteProducerId);
+    if (!consumer) return;
+
+    const event = pause ? 'voice:consumer:pause' : 'voice:consumer:resume';
+
+    try {
+      // 1. 서버에 요청 (서버가 나에게 보내는 패킷 밸브를 잠그거나 염)
+      await this.request(event, {
+        consumer_id: consumer.id,
+      });
+
+      // 2. 로컬 객체 상태 업데이트
+      if (pause) consumer.pause();
+      else consumer.resume();
+
+      console.log(`[수신 ${pause ? '중지' : '재개'}] 유저 ID: ${remoteProducerId}`);
+    } catch (error) {
+      console.error('컨슈머 상태 변경 실패:', error);
+    }
+  }
+
+  /**
+   * 7. 퇴장 및 정리
+   */
+  static async leaveChannel() {
+    if (!this.roomId) return;
+
+    await this.request('voice:room:leave', { room_id: this.roomId });
+    this.webRtc.cleanup();
+    this.consumers.clear();
+    this.myProducer = null;
+    this.roomId = null;
+  }
+
+  /**
+   * [리스너 1] 새로운 목소리가 들어왔을 때
+   */
+  private static async handleNewProducer(data: {
+    room_id: string;
+    user_id: string;
+    producer_id: string;
+  }) {
+    // 검증 1: 내가 현재 어느 방에도 참여 중이 아닐 때 무시
+    if (!this.roomId) return;
+
+    // 검증 2: 이벤트가 발생한 방과 내가 있는 방이 다를 때 무시
+    if (data.room_id !== this.roomId) return;
+
+    const stream = await this.consumeUser(data.user_id, data.producer_id);
+    if (stream) {
+      this.notify({ userId: data.user_id, isMicOn: true, stream, action: 'add' });
+    }
+  }
+
+  /**
+   * [리스너 2] 상대방이 마이크를 끄거나 켰을 때
+   */
+  private static handleProducerUpdate(data: {
+    room_id: string;
+    user_id: string;
+    is_mic_on: boolean;
+  }) {
+    // 검증: 방 체크
+    if (!this.roomId || data.room_id !== this.roomId) return;
+
+    const consumer = this.getConsumerByUserId(data.user_id);
+    if (!consumer) return;
+
+    // 상태에 따라 수신 트래픽 제어
+    if (data.is_mic_on) {
+      consumer.resume();
+    } else {
+      consumer.pause();
+    }
+
+    // UI 알림 (필요 시)
+    this.notify({ userId: data.user_id, isMicOn: data.is_mic_on, action: 'update' });
+  }
+
+  /**
+   * [리스너 3] 상대방이 방을 나갔을 때
+   */
+  private static handleProducerClosed(data: { room_id: string; producer_id: string }) {
+    // 검증: 방 체크
+    if (!this.roomId || data.room_id !== this.roomId) return;
+
+    const consumer = this.consumers.get(data.producer_id);
+    if (consumer) {
+      consumer.close();
+      this.consumers.delete(data.producer_id);
+      console.log(`[Voice] 컨슈머 제거 완료: ${data.producer_id}`);
+      this.notify({ userId: consumer.appData.userId as string, isMicOn: false, action: 'remove' });
+    }
+  }
+
+  /**
+   * 소켓 요청 유틸리티
+   * 요청을 보내고 응답을 기다림
+   */
+  private static request(event: string, data: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      WebSocketService.getSocket()?.emit(event, data, (res: any) => {
+        if (res.error) reject(res.error);
+        else resolve(res.data);
+      });
+    });
+  }
+
+  /**
+   * 유저 ID로 컨슈머를 찾아야 할 때 (예: voice:producer:update)
+   */
+  static getConsumerByUserId(userId: string) {
+    return Array.from(this.consumers.values()).find((c) => c.appData.userId === userId);
+  }
+}

--- a/fe/src/app/features/voice/services/VoiceService.ts
+++ b/fe/src/app/features/voice/services/VoiceService.ts
@@ -49,7 +49,9 @@ export class VoiceService {
 
     try {
       // (1) Router Capabilities 조회
-      const routerCaps = await this.request('voice:router:capabilities', { room_id: roomId });
+      const routerCaps = await WebSocketService.request('voice:router:capabilities', {
+        room_id: roomId,
+      });
 
       // (2) WebRTC 디바이스 초기화 (코덱 맞추기)
       await this.webRtc.initDevice(routerCaps);
@@ -72,7 +74,7 @@ export class VoiceService {
    */
   private static async setupTransport(roomId: string, producing: boolean) {
     // A. 서버에 Transport 생성 요청
-    const transportOptions = await this.request('voice:transport:create', {
+    const transportOptions = await WebSocketService.request('voice:transport:create', {
       room_id: roomId,
       producing,
     });
@@ -84,7 +86,7 @@ export class VoiceService {
     // C. [이벤트] 연결 시작 (Handshake)
     transport.on('connect', async ({ dtlsParameters }, callback, errback) => {
       try {
-        await this.request('voice:transport:connect', {
+        await WebSocketService.request('voice:transport:connect', {
           room_id: roomId,
           transport_id: transport.id,
           dtls_parameters: dtlsParameters,
@@ -99,7 +101,7 @@ export class VoiceService {
     if (producing) {
       transport.on('produce', async ({ kind, rtpParameters }, callback, errback) => {
         try {
-          const data = await this.request('voice:producer:create', {
+          const data = await WebSocketService.request('voice:producer:create', {
             room_id: roomId,
             transport_id: transport.id,
             kind,
@@ -134,7 +136,7 @@ export class VoiceService {
 
   static async stopMic() {
     if (!this.myProducer) return;
-    await this.request('voice:producer:close', {
+    await WebSocketService.request('voice:producer:close', {
       room_id: this.roomId,
       producer_id: this.myProducer.id,
     });
@@ -153,7 +155,7 @@ export class VoiceService {
         throw new Error('수신용 트랜스포트가 준비되지 않았습니다.');
       }
 
-      const consumerOptions = await this.request('voice:consumer:create', {
+      const consumerOptions = await WebSocketService.request('voice:consumer:create', {
         transport_id: recvTransportId,
         producer_id: remoteProducerId,
         rtp_capabilities: this.webRtc.rtpCapabilities, // 내 사양 전달
@@ -167,7 +169,7 @@ export class VoiceService {
       this.consumers.set(remoteProducerId, consumer);
 
       // 명세에 따라 수신 재개 요청
-      await this.request('voice:consumer:resume', { consumer_id: consumer.id });
+      await WebSocketService.request('voice:consumer:resume', { consumer_id: consumer.id });
 
       // 실제 오디오 재생 로직 (예: 오디오 태그 연결)
       const stream = new MediaStream([consumer.track]);
@@ -184,7 +186,7 @@ export class VoiceService {
     if (!this.myProducer) return;
 
     const event = pause ? 'voice:producer:pause' : 'voice:producer:resume';
-    await this.request(event, { producer_id: this.myProducer.id });
+    await WebSocketService.request(event, { producer_id: this.myProducer.id });
 
     if (pause) this.myProducer.pause();
     else this.myProducer.resume();
@@ -201,7 +203,7 @@ export class VoiceService {
 
     try {
       // 1. 서버에 요청 (서버가 나에게 보내는 패킷 밸브를 잠그거나 염)
-      await this.request(event, {
+      await WebSocketService.request(event, {
         consumer_id: consumer.id,
       });
 
@@ -221,7 +223,7 @@ export class VoiceService {
   static async leaveChannel() {
     if (!this.roomId) return;
 
-    await this.request('voice:room:leave', { room_id: this.roomId });
+    await WebSocketService.request('voice:room:leave', { room_id: this.roomId });
     this.webRtc.cleanup();
     this.consumers.clear();
     this.myProducer = null;
@@ -287,19 +289,6 @@ export class VoiceService {
       console.log(`[Voice] 컨슈머 제거 완료: ${data.producer_id}`);
       this.notify({ userId: consumer.appData.userId as string, isMicOn: false, action: 'remove' });
     }
-  }
-
-  /**
-   * 소켓 요청 유틸리티
-   * 요청을 보내고 응답을 기다림
-   */
-  private static request(event: string, data: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      WebSocketService.getSocket()?.emit(event, data, (res: any) => {
-        if (res.error) reject(res.error);
-        else resolve(res.data);
-      });
-    });
   }
 
   /**

--- a/fe/src/app/services/webRTC.service.ts
+++ b/fe/src/app/services/webRTC.service.ts
@@ -1,0 +1,88 @@
+import { Device, Transport, Producer, Consumer } from 'mediasoup-client/types';
+import * as mediasoupClient from 'mediasoup-client';
+
+export class WebRtcService {
+  private device: Device | null = null;
+  private sendTransport: Transport | null = null;
+  private recvTransport: Transport | null = null;
+
+  /**
+   * 1. 로컬 디바이스 초기화
+   * 서버의 rtpCapabilities를 받아 브라우저가 통신 가능한지 확인합니다.
+   */
+  async initDevice(routerRtpCapabilities: any): Promise<void> {
+    try {
+      this.device = new mediasoupClient.Device();
+      await this.device.load({ routerRtpCapabilities });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * 2. Transport 생성 (내부용)
+   * 서버에서 받은 정보를 바탕으로 실제 WebRTC 통로 객체를 만듭니다.
+   */
+  createTransport(direction: 'send' | 'recv', transportOptions: any): Transport {
+    if (!this.device) throw new Error('Device not initialized');
+
+    const transport =
+      direction === 'send'
+        ? this.device.createSendTransport(transportOptions)
+        : this.device.createRecvTransport(transportOptions);
+
+    // [중요] transport.on('connect') 이벤트는 VoiceService(지휘자)에서
+    // WebSocketService를 통해 서버에 'voice:transport:connect'를 보내도록 구현해야 합니다.
+
+    if (direction === 'send') this.sendTransport = transport;
+    else this.recvTransport = transport;
+
+    return transport;
+  }
+
+  /**
+   * 3. 마이크 스트림 송출 (Producer)
+   */
+  async produceAudio(track: MediaStreamTrack): Promise<Producer> {
+    if (!this.sendTransport) throw new Error('Send Transport 를 찾을 수 없습니다.');
+
+    // 서버에 'voice:producer:create'를 보내기 위한 파라미터를 생성합니다.
+    const producer = await this.sendTransport.produce({
+      track,
+    });
+
+    return producer;
+  }
+
+  /**
+   * 4. 상대방 스트림 수신 (Consumer)
+   */
+  async consumeAudio(consumerOptions: any): Promise<Consumer> {
+    if (!this.recvTransport) throw new Error('Recv Transport 를 찾을 수 없습니다.');
+
+    const consumer = await this.recvTransport.consume(consumerOptions);
+
+    // 필요하다면 여기서 바로 resume 처리를 하거나, 트랙을 리턴합니다.
+    return consumer;
+  }
+
+  /**
+   * 5. 리소스 정리 (Cleanup)
+   */
+  cleanup() {
+    this.sendTransport?.close();
+    this.recvTransport?.close();
+    this.sendTransport = null;
+    this.recvTransport = null;
+    this.device = null;
+  }
+
+  // Getters
+  get rtpCapabilities() {
+    return this.device?.rtpCapabilities;
+  }
+
+  get recvTransportId() {
+    return this.recvTransport?.id;
+  }
+}

--- a/fe/src/app/services/websocket.service.ts
+++ b/fe/src/app/services/websocket.service.ts
@@ -19,7 +19,7 @@ export class WebSocketService {
     onMessage?: (data: unknown) => void,
     onError?: (error: Error) => void,
   ): void {
-    // 이미 연결되어 있으면 재연결
+    // 이미 연결되어 있으면 재연결을 위해 기존 연결 해제
     if (this.socket?.connected) this.disconnect();
 
     const connectionOptions: any = {
@@ -32,15 +32,16 @@ export class WebSocketService {
     };
 
     // Mock 인증: query.userId 또는 auth.token 사용
-    if (userId) connectionOptions.query = { userId };
-    else {
+    if (userId) {
+      connectionOptions.query = { userId };
+    } else {
       const mockToken = this.getMockToken();
       if (mockToken) connectionOptions.auth = { token: mockToken };
     }
 
     this.socket = io(url, connectionOptions);
 
-    // 연결 완료 Promise 생성
+    // 연결 완료 Promise 관리
     const socket = this.socket;
     this.connectPromise = new Promise<void>((resolve) => {
       if (socket.connected) return resolve();
@@ -55,18 +56,14 @@ export class WebSocketService {
       socket.on('connect', connectHandler);
     });
 
-    // 이벤트 리스너 설정
-    this.socket.on('connect', () => {
-      // 연결 완료
-    });
-
-    this.socket.on('disconnect', (reason: any) => {
-      this.connectPromise = null;
-    });
-
     this.socket.on('connect_error', (error: any) => {
-      console.error('WebSocket connection error:', error);
+      console.error('[WebSocket] 연결 에러:', error);
       if (onError) onError(error);
+    });
+
+    this.socket.on('disconnect', (reason: string) => {
+      console.warn('[WebSocket] 연결 해제:', reason);
+      this.connectPromise = null;
     });
 
     // 모든 이벤트를 onMessage로 전달
@@ -78,7 +75,7 @@ export class WebSocketService {
   }
 
   /**
-   * Socket 인스턴스 가져오기 (이벤트 핸들러 등록용)
+   * Socket 인스턴스 가져오기
    */
   static getSocket(): Socket | null {
     return this.socket;
@@ -97,38 +94,55 @@ export class WebSocketService {
 
   /**
    * WebSocket 연결 완료 보장
-   * 이미 연결되어 있으면 즉시 resolve, 아니면 연결 완료까지 대기
    * @param timeout 타임아웃 (ms), 기본값 10초
    */
   static async ensureConnected(timeout: number = 10000): Promise<void> {
-    // 이미 연결되어 있으면 즉시 반환
     if (this.socket?.connected) return;
 
-    // 연결 중이면 기존 Promise 대기
     if (this.connectPromise) {
       return Promise.race([
         this.connectPromise,
         new Promise<void>((_, reject) =>
-          setTimeout(() => reject(new Error('WebSocket connection timeout')), timeout),
+          setTimeout(() => reject(new Error('[WebSocket] 연결 시간 초과')), timeout),
         ),
       ]);
     }
 
-    // 연결이 시작되지 않았으면 에러
-    throw new Error('WebSocket is not connecting. Call connect() first.');
+    throw new Error('[WebSocket] 연결이 시작되지 않았습니다. connect()를 먼저 호출하세요.');
   }
 
   /**
    * 메시지 전송
-   * @param event 이벤트 이름
-   * @param data 전송할 데이터
    */
   static send(event: string, data?: unknown): void {
     if (!this.socket?.connected) {
-      console.error('WebSocket is not connected');
+      console.error('[WebSocket] 메시지 전송 실패: 연결되지 않은 상태입니다.');
       return;
     }
     this.socket.emit(event, data);
+  }
+
+  /**
+   * 소켓 요청 유틸리티 (Ack 응답 대기)
+   */
+  static request(event: string, data: any, timeout = 5000): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const socket = this.socket;
+
+      if (!socket || !socket.connected) {
+        return reject(new Error('[WebSocket] 요청 실패: 연결되지 않은 상태입니다.'));
+      }
+
+      const timer = setTimeout(() => {
+        reject(new Error(`[WebSocket] 요청 응답 시간 초과: ${event}`));
+      }, timeout);
+
+      socket.emit(event, data, (res: any) => {
+        clearTimeout(timer);
+        if (res?.error) reject(new Error(`[WebSocket] 서버 에러: ${res.error}`));
+        else resolve(res?.data ?? res);
+      });
+    });
   }
 
   /**
@@ -139,7 +153,7 @@ export class WebSocketService {
   }
 
   /**
-   * Mock 토큰 가져오기 (authStore에서)
+   * Mock 토큰 가져오기
    */
   private static getMockToken(): string | null {
     if (IS.undefined(window)) return null;
@@ -162,32 +176,37 @@ export class WebSocketService {
 
   /**
    * 특정 이벤트 리스너 등록
-   * Chrome에서 이벤트 리스너가 제대로 등록되지 않는 문제를 해결하기 위해
-   * socket이 연결된 상태에서만 등록하도록 보장
    */
   static on(event: string, callback: (...args: any[]) => void): void {
     const registerListener = () => {
       if (!this.socket) {
-        // socket이 생성될 때까지 대기 후 등록
+        // socket 인스턴스가 없을 경우 연결될 때까지 재시도 (최대 50회)
+        let attempts = 0;
         const checkAndRegister = () => {
-          if (!this.socket) return setTimeout(checkAndRegister, 10);
-          registerListener();
+          attempts++;
+          if (this.socket) {
+            registerListener();
+          } else if (attempts < 50) {
+            setTimeout(checkAndRegister, 100);
+          } else {
+            console.error('[WebSocket] 리스너 등록 실패: Socket 인스턴스가 존재하지 않습니다.');
+          }
         };
         checkAndRegister();
         return;
       }
 
       if (!this.socket.connected) {
-        const connectHandler = () => {
-          this.socket?.off('connect', connectHandler);
+        this.socket.once('connect', () => {
           this.socket?.on(event, callback);
-        };
-        this.socket.once('connect', connectHandler);
+        });
         return;
       }
 
       this.socket.off(event, callback);
       this.socket.on(event, callback);
+
+      // 만약 이미 연결된 상태에서 connect 이벤트를 등록하려 한다면 즉시 콜백 실행
       if (event === 'connect' && this.socket.connected) callback();
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 11.1.11(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/websockets@11.1.11)(rxjs@7.8.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.0)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.0)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))
       '@nestjs/websockets':
         specifier: ^11.1.11
         version: 11.1.11(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)(@nestjs/platform-socket.io@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -87,7 +87,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21))
+        version: 10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)(@nestjs/platform-express@10.4.21)
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.25
@@ -151,6 +151,9 @@ importers:
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
+      mediasoup-client:
+        specifier: ^3.18.3
+        version: 3.18.3
       next:
         specifier: ^14.2.0
         version: 14.2.35(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -753,6 +756,10 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@lukeed/uuid@2.0.1':
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+
   '@mswjs/interceptors@0.40.0':
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
     engines: {node: '>=18'}
@@ -1191,6 +1198,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -1199,6 +1209,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/events@3.0.3':
+    resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
 
   '@types/express-serve-static-core@4.19.7':
     resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
@@ -1689,6 +1702,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  awaitqueue@3.3.0:
+    resolution: {integrity: sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==}
+    engines: {node: '>=20'}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -2457,6 +2474,10 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  fake-mediastreamtrack@2.2.1:
+    resolution: {integrity: sha512-SITLc7UTDirSdgLGORrlmqjWLJtbtfIz/xO7DwVbJH3f0ds+NQok4ccl/WEzz49NSgiUlXf2wDW0+y5C+TO6EA==}
+    engines: {node: '>=20'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2673,6 +2694,10 @@ packages:
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  h264-profile-level-id@2.3.2:
+    resolution: {integrity: sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==}
+    engines: {node: '>=20'}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -3307,6 +3332,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  mediasoup-client@3.18.3:
+    resolution: {integrity: sha512-ULypBvw4/2n6sEzhocZue61qtfQ2wvsIsppAikI65E7nh7V7eHajJaYtw432HdYnhryF9eO65rlDSqBmPh26CA==}
+    engines: {node: '>=20'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -3867,6 +3896,10 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  sdp-transform@3.0.0:
+    resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4133,6 +4166,10 @@ packages:
   supertest@7.2.2:
     resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
     engines: {node: '>=14.18.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4787,7 +4824,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4944,7 +4981,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5059,7 +5096,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5075,7 +5112,7 @@ snapshots:
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5350,6 +5387,10 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@lukeed/uuid@2.0.1':
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
   '@mswjs/interceptors@0.40.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -5483,7 +5524,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21))':
+  '@nestjs/testing@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)(@nestjs/platform-express@10.4.21)':
     dependencies:
       '@nestjs/common': 10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -5491,7 +5532,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.0)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.21)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.0)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 10.4.21(@nestjs/common@10.4.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@11.1.11)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -5705,7 +5746,7 @@ snapshots:
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fflate: 0.8.2
       token-types: 6.1.2
     transitivePeerDependencies:
@@ -5762,6 +5803,10 @@ snapshots:
     dependencies:
       '@types/node': 20.19.27
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -5773,6 +5818,8 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/events@3.0.3': {}
 
   '@types/express-serve-static-core@4.19.7':
     dependencies:
@@ -5903,7 +5950,7 @@ snapshots:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.2
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5913,7 +5960,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5932,7 +5979,7 @@ snapshots:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2)(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.2
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -5947,7 +5994,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 9.0.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -6332,6 +6379,12 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  awaitqueue@3.3.0(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -6723,9 +6776,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   dedent@1.7.1: {}
 
@@ -6811,7 +6866,7 @@ snapshots:
   engine.io-client@6.6.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io-parser: 5.2.3
       ws: 8.18.3
       xmlhttprequest-ssl: 2.1.2
@@ -6830,7 +6885,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -7023,7 +7078,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.2
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -7035,7 +7090,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2))(eslint@9.39.2):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7057,7 +7112,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2))(eslint@9.39.2)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7172,7 +7227,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -7291,6 +7346,10 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fake-mediastreamtrack@2.2.1:
+    dependencies:
+      '@lukeed/uuid': 2.0.1
 
   fast-deep-equal@3.1.3: {}
 
@@ -7537,6 +7596,12 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.12.0: {}
+
+  h264-profile-level-id@2.3.2(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   handlebars@4.7.8:
     dependencies:
@@ -7848,7 +7913,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -8389,6 +8454,18 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
+
+  mediasoup-client@3.18.3:
+    dependencies:
+      '@types/debug': 4.1.12
+      '@types/events-alias': '@types/events@3.0.3'
+      awaitqueue: 3.3.0(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
+      events-alias: events@3.3.0
+      fake-mediastreamtrack: 2.2.1
+      h264-profile-level-id: 2.3.2(supports-color@10.2.2)
+      sdp-transform: 3.0.0
+      supports-color: 10.2.2
 
   memfs@3.5.3:
     dependencies:
@@ -8974,6 +9051,8 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  sdp-transform@3.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
@@ -9092,7 +9171,7 @@ snapshots:
 
   socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -9102,7 +9181,7 @@ snapshots:
   socket.io-client@4.8.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io-client: 6.6.4
       socket.io-parser: 4.2.5
     transitivePeerDependencies:
@@ -9113,7 +9192,7 @@ snapshots:
   socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9122,7 +9201,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io: 6.6.5
       socket.io-adapter: 2.5.6
       socket.io-parser: 4.2.5
@@ -9293,7 +9372,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -9310,6 +9389,8 @@ snapshots:
       superagent: 10.3.0
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9543,7 +9624,7 @@ snapshots:
       app-root-path: 3.1.0
       buffer: 6.0.3
       dayjs: 1.11.19
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       dedent: 1.7.1
       dotenv: 16.6.1
       glob: 10.5.0
@@ -9646,7 +9727,7 @@ snapshots:
   vite-node@2.1.9(@types/node@20.19.27)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@20.19.27)(terser@5.44.1)
@@ -9681,7 +9762,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 1.1.2


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

1. request - response 흐름을 하나로 관리하기 위한 메서드 `request()` 추가
  - fe 수정 및 사용방법
    - WebSocketService.request('event', data)
    - 기존 send() 메서드를 request 로 바꾸기만 하면 됨
    - 또한 응답을 받는 경우 해당 메서드의 리턴값을 받으면 됨
    - 응답을 받기위한 별도 리스너를 등록하지 않아도 됨

  - be 수정 및 사용방법
    - 기존의 소켓응답을 위한 .emit() -> return 으로 수정
    - be는 정확히 알지 못하기 때문에 담당자가 확인 후 진행요망
----

2. 음성채팅 기능을 위한 webRTC service, voice service 추가

프론트에서 음성 채팅 서비스의 전체적인 흐름

1. **입장:** `joinVoiceChannel` 호출 → 소켓 리스너 등록 → 서버와 통로(Transport) 연결.
    
2. **발견:** 서버에서 `voice:new-producer` 전송 → `handleNewProducer`가 감지.
    
4. **수신:** `consumeUser` 실행 → `Consumer` 객체 생성 → `MediaStream` 포장.
    
5. **전파:** `notify({ action: 'add', stream })` 호출 → 구독 중인 `useVoiceChat` 훅의 상태 업데이트 → 화면에 소리 출력.


