### PR TITLE
[Fix] 최초 메시지 전송 시 두 개 표시되는 오류 수정

### DIFF
--- a/fe/src/app/features/chat/components/GlobalChatPanel.tsx
+++ b/fe/src/app/features/chat/components/GlobalChatPanel.tsx
@@ -42,10 +42,10 @@ export default function GlobalChatPanel() {
 
     subscribe();
 
-    // recents 수신 콜백 등록 (초기 메시지 로드 시 배열 교체)
+    // recents 수신 콜백 등록
     const unsubscribeRecents = globalChatService.onRecents((messages) => setChats(messages));
 
-    // 메시지 수신 콜백 등록 (새 메시지만 추가)
+    // 메시지 수신 콜백 등록
     const unsubscribeMessage = globalChatService.onMessage((message) =>
       setChats((prev) => [...prev, message]),
     );
@@ -55,7 +55,7 @@ export default function GlobalChatPanel() {
       setIsConnected(connected),
     );
 
-    // 참여자 수 변경 콜백 등록 (브로드캐스트 받은 데이터로 업데이트)
+    // 참여자 수 변경 콜백 등록
     const unsubscribeParticipants = globalChatService.onParticipantsChange((count) =>
       setCurrentParticipants(count),
     );

--- a/fe/src/app/features/chat/services/GlobalChatService.ts
+++ b/fe/src/app/features/chat/services/GlobalChatService.ts
@@ -12,7 +12,7 @@ import { ChatConverter } from '@/app/features/chat/dtos/converter';
 import { WS_EVENTS } from '@/app/services/events';
 import { WebSocketService } from '@/app/services/websocket.service';
 import { authStore } from '@/app/features/user/stores/auth';
-import { roomStore } from '@/app/features/room/stores/room';
+
 import {
   ChatChannel,
   MessageCallback,
@@ -127,7 +127,7 @@ export class GlobalChatService implements ChatChannel {
 
   private handleGlobalMessage(dto: ChatGlobalNewMessageDto): void {
     const chatData = ChatConverter.toGlobalNewMessageData(dto);
-    this.messages.push(chatData);
+    this.messages = [...this.messages, chatData];
     this.notifyMessage(chatData);
   }
 
@@ -175,7 +175,7 @@ export class GlobalChatService implements ChatChannel {
     const ackData = ChatConverter.toGlobalSendAckData(ackDto);
 
     // 변환된 Data를 로직에서 사용
-    this.messages.push(ackData);
+    this.messages = [...this.messages, ackData];
     this.notifyMessage(ackData);
   }
 

--- a/fe/src/app/features/chat/services/RoomChatService.ts
+++ b/fe/src/app/features/chat/services/RoomChatService.ts
@@ -204,7 +204,7 @@ export class RoomChatService {
     if (!dto.sender) return;
 
     const chatData = ChatConverter.toReceiveData(dto);
-    this.messages.push(chatData);
+    this.messages = [...this.messages, chatData];
     this.notifyMessage(chatData);
   }
 
@@ -289,7 +289,7 @@ export class RoomChatService {
     const ackData = ChatConverter.toRoomSendAckData(ackDto);
 
     // 변환된 Data를 로직에서 사용
-    this.messages.push(ackData);
+    this.messages = [...this.messages, ackData];
     this.notifyMessage(ackData);
   }
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [ ] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

- 글로벌 채팅에서 최초 메시지 전송 시 내 화면에서 두 개 보내진 것처럼 보이는 현상 수정

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [작성 예정]()
