### PR TITLE
[Feat] 방장 권한 자동 위임

### DIFF
--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -183,6 +183,10 @@ export const LOG = {
       message: `사용자 ${userId}가 방 ${roomId}에서 퇴장했습니다.`,
       level: 'log',
     }),
+    HOST_CHANGED: (roomId: string, newHostId: string): LogMessage => ({
+      message: `방장 변경: roomId=${roomId}, newHostId=${newHostId}`,
+      level: 'log',
+    }),
     PERMISSION_CHECK: (userId: string, roomId: string): LogMessage => ({
       message: `권한 검증: userId=${userId}, roomId=${roomId}`,
       level: 'debug',

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -164,11 +164,18 @@ export class RoomService implements OnModuleInit {
     await this.updateCurrentParticipants(roomId);
     logMessage(this.logger, LOG.ROOM.USER_LEFT(userId, roomId));
 
-    // 만약 방장이면 방 삭제 처리
+    // 만약 방장이면 방장 권한 랜덤으로 넘기기
     const isHost = await this.isHost(userId, roomId);
     if (isHost) {
-      await this.deleteRoom(userId, roomId, server);
-      return;
+      // await this.deleteRoom(userId, roomId, server);
+      const memberIds = await this.getRoomMemberIds(roomId);
+      if (memberIds.length > 0) {
+        const newHostId = memberIds[Math.floor(Math.random() * memberIds.length)];
+        await this.redisClient.hSet(`room:${roomId}`, 'host_id', newHostId);
+        logMessage(this.logger, LOG.ROOM.HOST_CHANGED(roomId, newHostId));
+
+        return;
+      }
     }
 
     // 빈 Local 방 삭제

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -164,13 +164,23 @@ export class RoomService implements OnModuleInit {
     await this.updateCurrentParticipants(roomId);
     logMessage(this.logger, LOG.ROOM.USER_LEFT(userId, roomId));
 
-    // 만약 방장이면 방장 권한 랜덤으로 넘기기
+    // 만약 방장이면 방장 권한 넘기기 -> join_date 기준으로 들어온 순서가 빠른 사람에게
     const isHost = await this.isHost(userId, roomId);
     if (isHost) {
-      // await this.deleteRoom(userId, roomId, server);
       const memberIds = await this.getRoomMemberIds(roomId);
       if (memberIds.length > 0) {
-        const newHostId = memberIds[Math.floor(Math.random() * memberIds.length)];
+        let earliestJoinDate: Date | null = null;
+        let newHostId: string = memberIds[0];
+        for (const memberId of memberIds) {
+          const memberDetails = await this.redisClient.hGetAll(`room:${roomId}:members:${memberId}`);
+          const joinDateStr = memberDetails.join_date;
+          const joinDate = new Date(joinDateStr);
+          if (!earliestJoinDate || joinDate < earliestJoinDate) {
+            earliestJoinDate = joinDate;
+            newHostId = memberId;
+          }
+        }
+
         await this.redisClient.hSet(`room:${roomId}`, 'host_id', newHostId);
         logMessage(this.logger, LOG.ROOM.HOST_CHANGED(roomId, newHostId));
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

## 방이 강제로 삭제될 때 게임 쪽 처리
### 문제
호스트가 비정상적으로 웹소켓 연결 끊긴 후 30초 후에도 재접속을 안할 떄(그럼 로그아웃 처리가 됨?) -> 멤버에서 삭제 -> 호스트가 나갔으므로 방이 강제로 삭제 -> 만약 게임중이라면??? -> 문제 발생!!!
호스트가 갑자기 로그아웃 함 → 방이 삭제됨 → 다른 멤버들 영문도 모른채 튕김
방장이 deleteRoom 할때와는 다른 상황임. deleteRoom 때는 기존처럼 그냥 다 나가지는게 맞고, 비정상적으로 웹소켓 연결이 끊긴 후 30초이거나, 명시적으로 로그아웃 했을 때(leaveRoom)가 문제인 것.
→ 방장 넘겨주기 기능이 있으면 문제 없음
### 해결
BE에서 해당 방에 가장 먼저 들어온 사람에게 방장을 지정해주도록 하는 방향으로 진행