### PR TITLE
[Fix] 세션 만료 시 Redis user:{userId}:rooms set 미삭제 버그 수정

### DIFF
--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -225,6 +225,8 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
       if (stillDisconnected) {
         await this.roomService.leaveAllRooms(this.server, userId);
         await this.roomService.clearUserSession(userId);
+        // user:${userId}:rooms Set을 Redis에서 삭제
+        await this.redisClient.del(`user:${userId}:rooms`);
 
         const globalRoomId = GLOBAL_ROOM_ID;
         if (globalRoomId) {
@@ -274,6 +276,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // 모든 세션 삭제
       await this.roomService.clearUserSession(userId);
       await this.redisClient.del(`user:session:${userId}`);
+      await this.redisClient.del(`user:${userId}:rooms`);
 
       // 참여자 수 조회 및 브로드캐스트
       const currentParticipants = await this.roomService.getCurrentParticipants(globalRoomId);

--- a/be/src/common/utils/time.utils.ts
+++ b/be/src/common/utils/time.utils.ts
@@ -1,0 +1,14 @@
+export function parseExpiresIn(expiresIn: string): number {
+  const value = parseInt(expiresIn, 10);
+  if (expiresIn.endsWith('s')) {
+    return value * 1000;
+  } else if (expiresIn.endsWith('m')) {
+    return value * 60 * 1000;
+  } else if (expiresIn.endsWith('h')) {
+    return value * 60 * 60 * 1000;
+  } else if (expiresIn.endsWith('d')) {
+    return value * 24 * 60 * 60 * 1000;
+  }
+  // 기본값 (예: 숫자로만 주어지면 초단위로 간주)
+  return value * 1000;
+}

--- a/be/src/modules/auth/auth.controller.ts
+++ b/be/src/modules/auth/auth.controller.ts
@@ -29,12 +29,13 @@ export class AuthController {
   @BypassTransform()
   async githubAuthCallback(@Req() req, @Res({ passthrough: true }) res: Response) {
     const { accessToken } = await this.authService.login(req.user);
+    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
 
     res.cookie('accessToken', accessToken, {
       httpOnly: true,
       secure: true, // sameSite: 'none' 일 때 필수
       sameSite: 'none',
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      expires: new Date(Date.now() + expiresInMs), // JWT 만료 시간에 맞춰 쿠키 만료 시간 설정
       path: '/',
     });
 
@@ -54,12 +55,13 @@ export class AuthController {
   @BypassTransform()
   async googleAuthCallback(@Req() req, @Res({ passthrough: true }) res: Response) {
     const { accessToken } = await this.authService.login(req.user);
+    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
 
     res.cookie('accessToken', accessToken, {
       httpOnly: true,
       secure: true,
       sameSite: 'none',
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      expires: new Date(Date.now() + expiresInMs), // JWT 만료 시간에 맞춰 쿠키 만료 시간 설정
       path: '/',
     });
 
@@ -73,13 +75,12 @@ export class AuthController {
   @Post('mock/login')
   async mockLogin(@Body() dto: MockLoginDto, @Res({ passthrough: true }) res: Response) {
     // Mock 사용자 확인
-    // MockAuthService에서 User 엔티티와 유사한 형태로 Mock 사용자 정보를 가져옴
     const mockUser = this.mockAuthService.getMockUserById(dto.userId);
     if (!mockUser) return { success: false, message: '존재하지 않는 Mock 사용자입니다.' };
 
     // Mock 사용자를 실제 User 엔티티 타입으로 변환 (필요한 속성만 매핑)
     const user: any = {
-      id: toUuid(mockUser.id), // Mock user ID를 UUID로 변환
+      id: toUuid(mockUser.id),
       email: mockUser.email,
       // 기타 필요한 User 엔티티 속성
     };
@@ -87,11 +88,13 @@ export class AuthController {
     // 실제 AuthService의 login 메소드를 사용하여 JWT 발급
     const { accessToken: token } = await this.authService.login(user);
 
+    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
+
     res.cookie('accessToken', token, {
       httpOnly: true,
       secure: true, // sameSite: 'none' 일 때 필수
       sameSite: 'none',
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 24), // 1일 후 만료
+      expires: new Date(Date.now() + expiresInMs),
       path: '/',
     });
 

--- a/be/src/modules/auth/auth.controller.ts
+++ b/be/src/modules/auth/auth.controller.ts
@@ -4,7 +4,6 @@ import { AuthService } from './auth.service';
 import { MockAuthService } from './mock-auth.service';
 import { GetMeResponseDto } from './dto/auth-response.dto';
 import { MockLoginDto, MockUserResponseDto } from './dto/mock-login.dto';
-import { toUuid } from '@src/common/utils/user-id';
 import { Response } from 'express';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { BypassTransform } from '@src/common/decorators/bypass-transform.decorator';
@@ -28,18 +27,7 @@ export class AuthController {
   @UseGuards(AuthGuard('github'))
   @BypassTransform()
   async githubAuthCallback(@Req() req, @Res({ passthrough: true }) res: Response) {
-    const { accessToken } = await this.authService.login(req.user);
-    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: true, // sameSite: 'none' 일 때 필수
-      sameSite: 'none',
-      expires: new Date(Date.now() + expiresInMs), // JWT 만료 시간에 맞춰 쿠키 만료 시간 설정
-      path: '/',
-    });
-
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
+    await this.authService.handleOAuthLogin(req.user, res);
   }
 
   // Google OAuth 로그인 라우트
@@ -54,18 +42,7 @@ export class AuthController {
   @UseGuards(AuthGuard('google'))
   @BypassTransform()
   async googleAuthCallback(@Req() req, @Res({ passthrough: true }) res: Response) {
-    const { accessToken } = await this.authService.login(req.user);
-    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      expires: new Date(Date.now() + expiresInMs), // JWT 만료 시간에 맞춰 쿠키 만료 시간 설정
-      path: '/',
-    });
-
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
+    await this.authService.handleOAuthLogin(req.user, res);
   }
 
   /**
@@ -74,43 +51,14 @@ export class AuthController {
    */
   @Post('mock/login')
   async mockLogin(@Body() dto: MockLoginDto, @Res({ passthrough: true }) res: Response) {
-    // Mock 사용자 확인
-    const mockUser = this.mockAuthService.getMockUserById(dto.userId);
-    if (!mockUser) return { success: false, message: '존재하지 않는 Mock 사용자입니다.' };
-
-    // Mock 사용자를 실제 User 엔티티 타입으로 변환 (필요한 속성만 매핑)
-    const user: any = {
-      id: toUuid(mockUser.id),
-      email: mockUser.email,
-      // 기타 필요한 User 엔티티 속성
-    };
-
-    // 실제 AuthService의 login 메소드를 사용하여 JWT 발급
-    const { accessToken: token } = await this.authService.login(user);
-
-    const expiresInMs = this.authService.getJwtExpirationInMs(); // AuthService에서 만료 시간 가져오기
-
-    res.cookie('accessToken', token, {
-      httpOnly: true,
-      secure: true, // sameSite: 'none' 일 때 필수
-      sameSite: 'none',
-      expires: new Date(Date.now() + expiresInMs),
-      path: '/',
-    });
-
-    // UUID 변환 (이미 user.id에서 변환됨)
-    const uuid = user.id;
-
+    const result = await this.authService.handleMockLogin(dto, res);
+    if (!result.success) {
+      return { success: false, message: '존재하지 않는 Mock 사용자입니다.' };
+    }
     return {
       success: true,
-      userId: uuid,
-      user: {
-        id: uuid,
-        email: mockUser.email,
-        nickname: mockUser.nickname,
-        profile_image: mockUser.profile_image,
-        role: mockUser.role,
-      },
+      userId: result.userId,
+      user: result.user,
     };
   }
 

--- a/be/src/modules/auth/auth.service.ts
+++ b/be/src/modules/auth/auth.service.ts
@@ -6,6 +6,10 @@ import { UserInfoResponseDto, UserWithRoleResponseDto } from './dto/auth-respons
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { parseExpiresIn } from '@src/common/utils/time.utils';
+import { Response } from 'express';
+import { MockAuthService } from './mock-auth.service';
+import { toUuid } from '@src/common/utils/user-id';
+import { MockLoginDto } from './dto/mock-login.dto';
 
 interface OAuthUser {
   githubId?: string;
@@ -23,6 +27,7 @@ export class AuthService {
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly mockAuthService: MockAuthService,
   ) {}
 
   // 랜덤 문자열 생성 헬퍼 함수
@@ -160,5 +165,71 @@ export class AuthService {
   public getJwtExpirationInMs(): number {
     const jwtExpirationTimeStr = this.configService.get<string>('JWT_EXPIRATION_TIME', '1h');
     return parseExpiresIn(jwtExpirationTimeStr);
+  }
+
+  /**
+   * 액세스 토큰을 HttpOnly 쿠키로 설정
+   */
+  public setAccessTokenCookie(res: Response, accessToken: string): void {
+    const expiresInMs = this.getJwtExpirationInMs();
+    res.cookie('accessToken', accessToken, {
+      httpOnly: true,
+      secure: true, // sameSite: 'none' 일 때 필수 (프로덕션 환경에서 true)
+      sameSite: 'none',
+      expires: new Date(Date.now() + expiresInMs),
+      path: '/',
+    });
+  }
+
+  /**
+   * OAuth 로그인 후 JWT를 발급하고 쿠키를 설정한 뒤 프론트엔드로 리다이렉션
+   */
+  public async handleOAuthLogin(user: User, res: Response): Promise<void> {
+    const { accessToken } = await this.login(user);
+    this.setAccessTokenCookie(res, accessToken);
+    res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
+  }
+
+  /**
+   * 개발용 Mock 로그인 처리 로직
+   */
+  public async handleMockLogin(
+    dto: MockLoginDto,
+    res: Response,
+  ): Promise<{ success: boolean; userId: string; user: any }> {
+    // Mock 사용자 확인
+    const mockUser = this.mockAuthService.getMockUserById(dto.userId);
+    if (!mockUser) {
+      // 컨트롤러에서 처리하는 응답과 일관성을 위해 예외 대신 객체 반환
+      return { success: false, userId: '', user: null };
+    }
+
+    // Mock 사용자를 실제 User 엔티티 타입으로 변환 (필요한 속성만 매핑)
+    const user: any = {
+      id: toUuid(mockUser.id), // Mock user ID를 UUID로 변환
+      email: mockUser.email,
+      nickname: mockUser.nickname,
+      profile_image: mockUser.profile_image,
+      role: mockUser.role,
+    };
+
+    // 실제 AuthService의 login 메소드를 사용하여 JWT 발급
+    const { accessToken: token } = await this.login(user);
+
+    this.setAccessTokenCookie(res, token);
+
+    const uuid = user.id;
+
+    return {
+      success: true,
+      userId: uuid,
+      user: {
+        id: uuid,
+        email: mockUser.email,
+        nickname: mockUser.nickname,
+        profile_image: mockUser.profile_image,
+        role: mockUser.role,
+      },
+    };
   }
 }

--- a/be/src/modules/auth/auth.service.ts
+++ b/be/src/modules/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { User } from '../user/user.entity';
 import { UserInfoResponseDto, UserWithRoleResponseDto } from './dto/auth-response.dto';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { parseExpiresIn } from '@src/common/utils/time.utils';
 
 interface OAuthUser {
   githubId?: string;
@@ -151,5 +152,13 @@ export class AuthService {
     }
 
     return new UserWithRoleResponseDto(user);
+  }
+
+  /**
+   * JWT 토큰 만료시간 조회
+   */
+  public getJwtExpirationInMs(): number {
+    const jwtExpirationTimeStr = this.configService.get<string>('JWT_EXPIRATION_TIME', '1h');
+    return parseExpiresIn(jwtExpirationTimeStr);
   }
 }

--- a/be/src/modules/room/room.repository.ts
+++ b/be/src/modules/room/room.repository.ts
@@ -252,6 +252,13 @@ export class RoomRepository {
   }
 
   /**
+   * 사용자 참여 방 목록 Set을 Redis에서 삭제 (user:${userId}:rooms)
+   */
+  async deleteUserRoomsSet(userId: string): Promise<void> {
+    await this.redisClient.del(`user:${userId}:rooms`);
+  }
+
+  /**
    * 현재 참여자 수 조회
    */
   async getCurrentParticipants(roomId: string): Promise<number> {

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -503,6 +503,13 @@ export class RoomService implements OnModuleInit {
     for (const roomId of rooms) {
       await this.leaveRoomProcess(server, userId, roomId, client);
     }
+
+    // 모든 방에서 나간 후 user:${userId}:rooms Set이 비어있으면 삭제
+    const remainingRooms = await this.roomRepository.getUserRooms(userId);
+    if (remainingRooms.length === 0) {
+      // user:${userId}:rooms Set을 Redis에서 삭제
+      await this.roomRepository.deleteUserRoomsSet(userId);
+    }
   }
 
   /**


### PR DESCRIPTION
## 📝 작업 내용
> 세션 만료 시 Redis에 저장된 사용자 방 정보(user:{userId}:rooms set)가 제대로 삭제되지 않던 버그 수정

- [ ] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

- `app.gateway.ts`: 클라이언트 연결 해제 및 세션 만료 시 `redisClient.del(user:${userId}:rooms)`를 호출하여 Redis에서 `user:{userId}:rooms` set을 직접 삭제하도록 추가
- `room.repository.ts: deleteUserRoomsSet(userId: string)` 메서드를 추가하여 `user:{userId}:rooms` set 삭제 로직을 캡슐화
- `room.service.ts: leaveAllRooms` 메서드에서 사용자가 모든 방을 떠났을 때, `user:{userId}:rooms` set에 더 이상 방이 남아있지 않으면 `roomRepository.deleteUserRoomsSet(userId)`를 호출하여 해당 set을 삭제하도록 로직 추가

---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- close #286 

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [이슈 해결 과정: 토큰 만료 시 Redis 데이터 정리](https://rapid-bubble-113.notion.site/Redis-2fc207f2334180edbf36cd865e5a9029?source=copy_link)

---

### ✅ 기타 메모
> 기타 전달하고 싶은 내용이 있다면 자유롭게 작성

- 