### PR TITLE
[Refactor] chat 도메인 리팩토링 및 중복 코드 최소화, 글로벌 채팅방 버그 수정, 비속어 필터링 수정, sonar qube 검사

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,11 @@ $RECYCLE.BIN/
 
 docs/
 .acommit/
+
+# SonarQube 임시 작업 폴더 및 로그
+.scannerwork/
+.sonar_lock
+
+# 설정 파일 (토큰이 포함되어 있다면 보안을 위해 제외 권장)
+# 만약 토큰을 환경 변수로 관리한다면 올려도 되지만, 파일에 직접 썼다면 제외해야 함
+sonar-project.properties

--- a/be/package.json
+++ b/be/package.json
@@ -29,7 +29,8 @@
     "migration:revert:prod": "NODE_ENV=production pnpm typeorm:prod migration:revert -d dist/providers/database/data-source.js",
     "migration:create": "pnpm typeorm migration:create src/providers/database/migrations/init",
     "seed:users": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-users.ts",
-    "seed:game-records": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-game-records.ts"
+    "seed:game-records": "DB_HOST=localhost DB_PORT=3307 ts-node -P ./tsconfig.json -r tsconfig-paths/register src/scripts/seed-game-records.ts",
+    "sonar": "sonar-scanner"
   },
   "dependencies": {
     "@google/genai": "^1.38.0",

--- a/be/package.json
+++ b/be/package.json
@@ -81,6 +81,7 @@
     "globals": "^16.5.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
+    "sonarqube-scanner": "^4.3.4",
     "source-map-support": "^0.5.21",
     "supertest": "^7.1.4",
     "ts-jest": "^29.1.0",

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -40,7 +40,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
   server: Server;
 
   private readonly logger = new Logger(AppGateway.name);
-  private disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
+  private readonly disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
 
   constructor(
     private readonly chatService: ChatService,

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -15,12 +15,7 @@ import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
 import { RedisClientType } from 'redis';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import { GLOBAL_ROOM_ID, USER_SESSION_EXPIRATION_TIME } from '@src/common/constants/constants';
-import {
-  WS_EVENTS_AUTH,
-  WS_EVENTS_ROOM,
-  WS_EVENTS_CHAT,
-  WS_EVENTS_GAME,
-} from '@src/common/constants/ws-events.constant';
+import { WS_EVENTS_AUTH, WS_EVENTS_ROOM, WS_EVENTS_GAME } from '@src/common/constants/ws-events.constant';
 import { GameService } from './modules/game/game.service';
 import { GameCloseBroadcastDto } from './modules/game/dto/game-response.dto';
 import { ChatService } from './modules/chat/chat.service';
@@ -104,9 +99,6 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
             logMessage(this.logger, LOG.WS.ROOM_PARTICIPATION_CHECK_ERROR(errorMessage));
           }
         }
-
-        // 글로벌 룸 최신 메시지 전송 (인증/비인증 모두)
-        await this.sendGlobalChatRecents(client, globalRoomId, userId || null);
       }
 
       // 인증된 사용자의 경우 세션 복구 및 로컬 방 재참여 처리
@@ -285,39 +277,6 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logMessage(this.logger, LOG.WS.LOGOUT_ERROR(errorMessage));
-    }
-  }
-
-  // 글로벌 룸 입장 시 최신 메시지 및 참여자 수 전송
-  private async sendGlobalChatRecents(client: Socket, roomId: string, userId: string | null): Promise<void> {
-    try {
-      const [recents, currentParticipants] = await Promise.all([
-        this.chatService.getGlobalChatRecents(roomId, userId ? userId : undefined),
-        this.roomService.getCurrentParticipants(roomId),
-      ]);
-
-      const messages = recents.map((msg) => ({
-        message: msg.message,
-        sender: {
-          role: msg.sender.role,
-          nickname: msg.sender.nickname,
-          profile_image: msg.sender.profile_image,
-          is_me: userId ? msg.sender.is_me : false,
-        },
-        timestamp: msg.timestamp ?? new Date().toISOString(),
-      }));
-
-      client.emit(WS_EVENTS_CHAT.GLOBAL_INIT, {
-        messages,
-        current_participants: currentParticipants,
-      });
-
-      this.logger.debug(
-        `글로벌 채팅 최신 메시지 전송: roomId=${roomId}, userId=${userId || 'anonymous'}, count=${recents.length}`,
-      );
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`글로벌 채팅 최신 메시지 전송 실패: ${errorMessage}`);
     }
   }
 }

--- a/be/src/app.gateway.ts
+++ b/be/src/app.gateway.ts
@@ -23,6 +23,7 @@ import {
 } from '@src/common/constants/ws-events.constant';
 import { GameService } from './modules/game/game.service';
 import { GameCloseBroadcastDto } from './modules/game/dto/game-response.dto';
+import { ChatService } from './modules/chat/chat.service';
 
 @UseFilters(new WsExceptionFilter()) // 필터
 @WebSocketGateway({ namespace: '/' })
@@ -47,6 +48,7 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
 
   constructor(
+    private readonly chatService: ChatService,
     private readonly roomService: RoomService,
     private readonly gameService: GameService,
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
@@ -290,19 +292,19 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private async sendGlobalChatRecents(client: Socket, roomId: string, userId: string | null): Promise<void> {
     try {
       const [recents, currentParticipants] = await Promise.all([
-        this.roomService.getGlobalChatRecents(roomId),
+        this.chatService.getGlobalChatRecents(roomId, userId ? userId : undefined),
         this.roomService.getCurrentParticipants(roomId),
       ]);
 
       const messages = recents.map((msg) => ({
-        message: msg.content,
+        message: msg.message,
         sender: {
-          role: msg.role,
-          nickname: msg.nickname,
-          profile_image: msg.profile_image,
-          is_me: userId ? msg.sender_id === userId : false,
+          role: msg.sender.role,
+          nickname: msg.sender.nickname,
+          profile_image: msg.sender.profile_image,
+          is_me: userId ? msg.sender.is_me : false,
         },
-        timestamp: msg.create_date,
+        timestamp: msg.timestamp ?? new Date().toISOString(),
       }));
 
       client.emit(WS_EVENTS_CHAT.GLOBAL_INIT, {

--- a/be/src/common/utils/log-messages.ts
+++ b/be/src/common/utils/log-messages.ts
@@ -19,6 +19,10 @@ interface LogMessage {
 export const LOG = {
   // WebSocket 연결 관련
   WS: {
+    GLOBAL_INIT_ERROR: (error: string): LogMessage => ({
+      message: `글로벌 채팅 최신 메시지 조회 실패: ${error}`,
+      level: 'error',
+    }),
     CONNECT: (socketId: string, userId?: string): LogMessage => ({
       message: `클라이언트 연결: socketId=${socketId}, userId=${userId ?? 'anonymous'}`,
       level: 'log',

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -50,7 +50,7 @@ export class ChatGateway {
         return;
       }
       const currentParticipants = await this.roomService.getCurrentParticipants(roomId);
-      const recents = await this.chatService.getGlobalChatRecents(roomId, userId ? userId : undefined);
+      const recents = await this.chatService.getGlobalChatRecents(roomId, userId);
       return {
         messages: recents,
         current_participants: currentParticipants,

--- a/be/src/modules/chat/chat.gateway.ts
+++ b/be/src/modules/chat/chat.gateway.ts
@@ -38,6 +38,34 @@ export class ChatGateway {
     private readonly authService: AuthService,
   ) {}
 
+  // 글로벌 채팅 최신 메시지 조회
+  @SubscribeMessage(WS_EVENTS_CHAT.GLOBAL_INIT)
+  async handleGlobalInit(@ConnectedSocket() client: Socket) {
+    try {
+      const userId = client.data.userId;
+      const roomId = await this.roomService.getUserGlobalRoom();
+      if (!roomId) {
+        logMessage(this.logger, LOG.CHAT.NOT_MEMBER_SEND(userId, 'global'));
+        client.emit(WS_EVENTS_ERROR.ERROR, createWsError('NOT_FOUND', '글로벌 채팅방에 참여하지 않았습니다.'));
+        return;
+      }
+      const currentParticipants = await this.roomService.getCurrentParticipants(roomId);
+      const recents = await this.chatService.getGlobalChatRecents(roomId, userId ? userId : undefined);
+      return {
+        messages: recents,
+        current_participants: currentParticipants,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      logMessage(this.logger, LOG.WS.GLOBAL_INIT_ERROR(errorMessage));
+
+      const errorResponse = createWsErrorResponse(error, '메시지 전송 중 문제가 발생했습니다.');
+      client.emit(WS_EVENTS_ERROR.ERROR, errorResponse);
+      return;
+    }
+  }
+
   // 글로벌 채팅 메시지 수신 및 브로드캐스트
   @SubscribeMessage(WS_EVENTS_CHAT.GLOBAL_SEND)
   async handleGlobalChat(@ConnectedSocket() client: Socket, @MessageBody() dto: GlobalChatSendDto) {

--- a/be/src/modules/chat/chat.module.ts
+++ b/be/src/modules/chat/chat.module.ts
@@ -1,13 +1,15 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
+import { ChatRepository } from './chat.repository';
 import { RoomModule } from '@src/modules/room/room.module';
 import { AuthModule } from '@src/modules/auth/auth.module';
 import { CurseWordModule } from '@src/modules/curse-word/curse-word.module';
+import { RedisModule } from '@src/providers/redis/redis.module';
 
 @Module({
-  imports: [forwardRef(() => RoomModule), AuthModule, CurseWordModule],
-  providers: [ChatService, ChatGateway],
+  imports: [forwardRef(() => RoomModule), AuthModule, CurseWordModule, RedisModule],
+  providers: [ChatService, ChatGateway, ChatRepository],
   exports: [ChatService],
 })
 export class ChatModule {}

--- a/be/src/modules/chat/chat.repository.ts
+++ b/be/src/modules/chat/chat.repository.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { RedisClientType } from 'redis';
+import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
+import { GlobalChatRecentMessageDto } from './dto/chat-response.dto';
+
+@Injectable()
+export class ChatRepository {
+  private readonly logger = new Logger(ChatRepository.name);
+
+  constructor(@Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType) {}
+
+  /**
+   * 방 채팅 최신 메시지 조회 (최대 30개)
+   */
+  async getRoomChatRecents(roomId: string, currentUserId?: string): Promise<GlobalChatRecentMessageDto[]> {
+    try {
+      const recentsKey = `room:${roomId}:recents`;
+      const messages = await this.redisClient.lRange(recentsKey, 0, -1);
+
+      return messages.map((msg) => this.normalizeRecentMessage(JSON.parse(msg), currentUserId));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`방 채팅 최신 메시지 조회 실패: ${errorMessage}`);
+      return [];
+    }
+  }
+
+  /**
+   * 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+   */
+  async saveGlobalChatMessage(
+    roomId: string,
+    senderId: string,
+    content: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    createDate: string,
+  ): Promise<void> {
+    try {
+      const recentsKey = `room:${roomId}:recents`;
+      const messageData = {
+        sender_id: senderId,
+        message: content,
+        content,
+        sender: {
+          role: senderInfo.role,
+          nickname: senderInfo.nickname,
+          profile_image: senderInfo.profile_image ?? null,
+          is_me: false,
+        },
+        role: senderInfo.role,
+        nickname: senderInfo.nickname,
+        profile_image: senderInfo.profile_image ?? null,
+        timestamp: createDate,
+        create_date: createDate,
+      };
+
+      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
+      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
+
+      // 최신 30개만 유지 (오래된 메시지 제거)
+      await this.redisClient.lTrim(recentsKey, -30, -1);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`글로벌 채팅 메시지 저장 실패: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+   */
+  async saveRoomChatMessage(
+    roomId: string,
+    senderId: string,
+    content: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    createDate: string,
+  ): Promise<void> {
+    try {
+      const recentsKey = `room:${roomId}:recents`;
+      const messageData = {
+        sender_id: senderId,
+        message: content,
+        content,
+        sender: {
+          role: senderInfo.role,
+          nickname: senderInfo.nickname,
+          profile_image: senderInfo.profile_image ?? null,
+          is_me: false,
+        },
+        role: senderInfo.role,
+        nickname: senderInfo.nickname,
+        profile_image: senderInfo.profile_image ?? null,
+        timestamp: createDate,
+        create_date: createDate,
+      };
+
+      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
+      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
+
+      // 최신 30개만 유지 (오래된 메시지 제거)
+      await this.redisClient.lTrim(recentsKey, -30, -1);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`방 채팅 메시지 저장 실패: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Redis에서 조회한 메시지를 표준 형식으로 정규화
+   */
+  private normalizeRecentMessage(message: Record<string, any>, currentUserId?: string): GlobalChatRecentMessageDto {
+    const sender =
+      message.sender ??
+      ({
+        role: message.role ?? 'USER',
+        nickname: message.nickname ?? '',
+        profile_image: message.profile_image ?? null,
+        is_me: false,
+      } as GlobalChatRecentMessageDto['sender']);
+
+    const senderId = message.sender_id;
+    const isMe = currentUserId ? senderId === currentUserId : Boolean(sender.is_me);
+
+    return {
+      message: message.message ?? message.content ?? '',
+      sender: {
+        role: sender.role ?? 'USER',
+        nickname: sender.nickname ?? '',
+        profile_image: sender.profile_image ?? null,
+        is_me: isMe,
+      },
+      timestamp: message.timestamp ?? message.create_date ?? new Date().toISOString(),
+    };
+  }
+}

--- a/be/src/modules/chat/chat.repository.ts
+++ b/be/src/modules/chat/chat.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { RedisClientType } from 'redis';
 import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
-import { GlobalChatRecentMessageDto } from './dto/chat-response.dto';
+import { ChatRecentMessageDto } from './dto/chat-response.dto';
 
 @Injectable()
 export class ChatRepository {
@@ -10,28 +10,27 @@ export class ChatRepository {
   constructor(@Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType) {}
 
   /**
-   * 방 채팅 최신 메시지 조회 (최대 30개)
+   * 글로벌/로컬 채팅 최신 메시지 조회
    */
-  async getRoomChatRecents(roomId: string, currentUserId?: string): Promise<GlobalChatRecentMessageDto[]> {
+  async getChatRecents(roomId: string, currentUserId?: string): Promise<ChatRecentMessageDto[]> {
     try {
       const recentsKey = `room:${roomId}:recents`;
       const messages = await this.redisClient.lRange(recentsKey, 0, -1);
-
       return messages.map((msg) => this.normalizeRecentMessage(JSON.parse(msg), currentUserId));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`방 채팅 최신 메시지 조회 실패: ${errorMessage}`);
+      this.logger.error(`채팅 최신 메시지 조회 실패: ${errorMessage}`);
       return [];
     }
   }
 
   /**
-   * 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+   * 글로벌/로컬 채팅 메시지를 Redis에 저장 (최신 30개 유지)
    */
-  async saveGlobalChatMessage(
+  async saveChatMessage(
     roomId: string,
     senderId: string,
-    content: string,
+    message: string,
     senderInfo: { role: string; nickname: string; profile_image: string | null },
     createDate: string,
   ): Promise<void> {
@@ -39,19 +38,14 @@ export class ChatRepository {
       const recentsKey = `room:${roomId}:recents`;
       const messageData = {
         sender_id: senderId,
-        message: content,
-        content,
+        message: message,
         sender: {
           role: senderInfo.role,
           nickname: senderInfo.nickname,
           profile_image: senderInfo.profile_image ?? null,
           is_me: false,
         },
-        role: senderInfo.role,
-        nickname: senderInfo.nickname,
-        profile_image: senderInfo.profile_image ?? null,
         timestamp: createDate,
-        create_date: createDate,
       };
 
       // List의 오른쪽에 추가 (최신 메시지가 뒤에)
@@ -61,75 +55,35 @@ export class ChatRepository {
       await this.redisClient.lTrim(recentsKey, -30, -1);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`글로벌 채팅 메시지 저장 실패: ${errorMessage}`);
-    }
-  }
-
-  /**
-   * 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-   */
-  async saveRoomChatMessage(
-    roomId: string,
-    senderId: string,
-    content: string,
-    senderInfo: { role: string; nickname: string; profile_image: string | null },
-    createDate: string,
-  ): Promise<void> {
-    try {
-      const recentsKey = `room:${roomId}:recents`;
-      const messageData = {
-        sender_id: senderId,
-        message: content,
-        content,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image ?? null,
-          is_me: false,
-        },
-        role: senderInfo.role,
-        nickname: senderInfo.nickname,
-        profile_image: senderInfo.profile_image ?? null,
-        timestamp: createDate,
-        create_date: createDate,
-      };
-
-      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
-      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
-
-      // 최신 30개만 유지 (오래된 메시지 제거)
-      await this.redisClient.lTrim(recentsKey, -30, -1);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`방 채팅 메시지 저장 실패: ${errorMessage}`);
+      this.logger.error(`채팅 메시지 저장 실패: ${errorMessage}`);
     }
   }
 
   /**
    * Redis에서 조회한 메시지를 표준 형식으로 정규화
    */
-  private normalizeRecentMessage(message: Record<string, any>, currentUserId?: string): GlobalChatRecentMessageDto {
+  private normalizeRecentMessage(msg: Record<string, any>, currentUserId?: string): ChatRecentMessageDto {
     const sender =
-      message.sender ??
+      msg.sender ??
       ({
-        role: message.role ?? 'USER',
-        nickname: message.nickname ?? '',
-        profile_image: message.profile_image ?? null,
+        role: msg.role ?? 'USER',
+        nickname: msg.nickname ?? '',
+        profile_image: msg.profile_image ?? null,
         is_me: false,
-      } as GlobalChatRecentMessageDto['sender']);
+      } as ChatRecentMessageDto['sender']);
 
-    const senderId = message.sender_id;
+    const senderId = msg.sender_id;
     const isMe = currentUserId ? senderId === currentUserId : Boolean(sender.is_me);
 
     return {
-      message: message.message ?? message.content ?? '',
+      message: msg.message ?? '',
       sender: {
         role: sender.role ?? 'USER',
         nickname: sender.nickname ?? '',
         profile_image: sender.profile_image ?? null,
         is_me: isMe,
       },
-      timestamp: message.timestamp ?? message.create_date ?? new Date().toISOString(),
+      timestamp: msg.timestamp ?? msg.create_date ?? new Date().toISOString(),
     };
   }
 }

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Server } from 'socket.io';
 import { LOG, logMessage } from '@src/common/utils/log-messages';
 import {
@@ -6,19 +6,18 @@ import {
   LocalChatMessageResponseDto,
   GlobalChatRecentMessageDto,
 } from './dto/chat-response.dto';
-import { REDIS_CLIENT } from '@src/providers/redis/redis.provider';
-import { RedisClientType } from 'redis';
 import { GLOBAL_ROOM_ID, USER_TYPE } from '@src/common/constants/constants';
 import { WS_EVENTS_CHAT } from '@src/common/constants/ws-events.constant';
 import { CurseWordService } from '@src/modules/curse-word/curse-word.service';
 import { RoomService } from '../room/room.service';
+import { ChatRepository } from './chat.repository';
 
 @Injectable()
 export class ChatService {
   private readonly logger = new Logger(ChatService.name);
 
   constructor(
-    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
+    private readonly chatRepository: ChatRepository,
     private readonly curseWordService: CurseWordService,
     private readonly roomService: RoomService,
   ) {}
@@ -53,7 +52,7 @@ export class ChatService {
 
     // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
     if (roomId === GLOBAL_ROOM_ID) {
-      await this.saveGlobalChatMessage(roomId, userId, message, senderInfo, timestamp);
+      await this.chatRepository.saveGlobalChatMessage(roomId, userId, message, senderInfo, timestamp);
     }
 
     logMessage(this.logger, LOG.CHAT.GLOBAL_BROADCAST(userId, message));
@@ -158,7 +157,7 @@ export class ChatService {
     server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.ROOM_NEW_MESSAGE, responseToOthers.data);
 
     // 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-    await this.saveRoomChatMessage(roomId, userId, message, senderInfo, timestamp);
+    await this.chatRepository.saveRoomChatMessage(roomId, userId, message, senderInfo, timestamp);
 
     logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
 
@@ -167,116 +166,6 @@ export class ChatService {
 
   // 방 채팅 최신 메시지 조회 (최대 30개)
   async getRoomChatRecents(roomId: string, currentUserId?: string): Promise<GlobalChatRecentMessageDto[]> {
-    try {
-      const recentsKey = `room:${roomId}:recents`;
-      const messages = await this.redisClient.lRange(recentsKey, 0, -1);
-
-      return messages.map((msg) => this.normalizeRecentMessage(JSON.parse(msg), currentUserId));
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`방 채팅 최신 메시지 조회 실패: ${errorMessage}`);
-      return [];
-    }
-  }
-
-  // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-  private async saveGlobalChatMessage(
-    roomId: string,
-    senderId: string,
-    content: string,
-    senderInfo: { role: string; nickname: string; profile_image: string | null },
-    createDate: string,
-  ): Promise<void> {
-    try {
-      const recentsKey = `room:${roomId}:recents`;
-      const messageData = {
-        sender_id: senderId,
-        message: content,
-        content,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image ?? null,
-          is_me: false,
-        },
-        role: senderInfo.role,
-        nickname: senderInfo.nickname,
-        profile_image: senderInfo.profile_image ?? null,
-        timestamp: createDate,
-        create_date: createDate,
-      };
-
-      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
-      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
-
-      // 최신 30개만 유지 (오래된 메시지 제거)
-      await this.redisClient.lTrim(recentsKey, -30, -1);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`글로벌 채팅 메시지 저장 실패: ${errorMessage}`);
-    }
-  }
-
-  // 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-  private async saveRoomChatMessage(
-    roomId: string,
-    senderId: string,
-    content: string,
-    senderInfo: { role: string; nickname: string; profile_image: string | null },
-    createDate: string,
-  ): Promise<void> {
-    try {
-      const recentsKey = `room:${roomId}:recents`;
-      const messageData = {
-        sender_id: senderId,
-        message: content,
-        content,
-        sender: {
-          role: senderInfo.role,
-          nickname: senderInfo.nickname,
-          profile_image: senderInfo.profile_image ?? null,
-          is_me: false,
-        },
-        role: senderInfo.role,
-        nickname: senderInfo.nickname,
-        profile_image: senderInfo.profile_image ?? null,
-        timestamp: createDate,
-        create_date: createDate,
-      };
-
-      // List의 오른쪽에 추가 (최신 메시지가 뒤에)
-      await this.redisClient.rPush(recentsKey, JSON.stringify(messageData));
-
-      // 최신 30개만 유지 (오래된 메시지 제거)
-      await this.redisClient.lTrim(recentsKey, -30, -1);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`방 채팅 메시지 저장 실패: ${errorMessage}`);
-    }
-  }
-
-  private normalizeRecentMessage(message: Record<string, any>, currentUserId?: string): GlobalChatRecentMessageDto {
-    const sender =
-      message.sender ??
-      ({
-        role: message.role ?? 'USER',
-        nickname: message.nickname ?? '',
-        profile_image: message.profile_image ?? null,
-        is_me: false,
-      } as GlobalChatRecentMessageDto['sender']);
-
-    const senderId = message.sender_id;
-    const isMe = currentUserId ? senderId === currentUserId : Boolean(sender.is_me);
-
-    return {
-      message: message.message ?? message.content ?? '',
-      sender: {
-        role: sender.role ?? 'USER',
-        nickname: sender.nickname ?? '',
-        profile_image: sender.profile_image ?? null,
-        is_me: isMe,
-      },
-      timestamp: message.timestamp ?? message.create_date ?? new Date().toISOString(),
-    };
+    return this.chatRepository.getRoomChatRecents(roomId, currentUserId);
   }
 }

--- a/be/src/modules/chat/chat.service.ts
+++ b/be/src/modules/chat/chat.service.ts
@@ -4,9 +4,9 @@ import { LOG, logMessage } from '@src/common/utils/log-messages';
 import {
   GlobalChatMessageResponseDto,
   LocalChatMessageResponseDto,
-  GlobalChatRecentMessageDto,
+  ChatRecentMessageDto,
 } from './dto/chat-response.dto';
-import { GLOBAL_ROOM_ID, USER_TYPE } from '@src/common/constants/constants';
+import { USER_TYPE } from '@src/common/constants/constants';
 import { WS_EVENTS_CHAT } from '@src/common/constants/ws-events.constant';
 import { CurseWordService } from '@src/modules/curse-word/curse-word.service';
 import { RoomService } from '../room/room.service';
@@ -51,13 +51,51 @@ export class ChatService {
     server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.GLOBAL_NEW_MESSAGE, responseToOthers.data);
 
     // 글로벌 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-    if (roomId === GLOBAL_ROOM_ID) {
-      await this.chatRepository.saveGlobalChatMessage(roomId, userId, message, senderInfo, timestamp);
-    }
+    await this.chatRepository.saveChatMessage(roomId, userId, message, senderInfo, timestamp);
 
     logMessage(this.logger, LOG.CHAT.GLOBAL_BROADCAST(userId, message));
 
     return message;
+  }
+
+  /**
+   * 글로벌 채팅 최신 메시지 조회
+   */
+  async getGlobalChatRecents(roomId: string, currentUserId?: string): Promise<ChatRecentMessageDto[]> {
+    return await this.chatRepository.getChatRecents(roomId, currentUserId);
+  }
+
+  // 방 채팅 메시지 브로드캐스트
+  async broadcastRoomChat(
+    server: Server,
+    roomId: string,
+    userId: string,
+    message: string,
+    senderInfo: { role: string; nickname: string; profile_image: string | null },
+    senderSocketId: string,
+  ): Promise<string> {
+    const timestamp = new Date().toISOString();
+
+    const { sanitized, hasCurse } = await this.curseWordService.sanitize(message);
+    if (hasCurse) {
+      message = sanitized;
+    }
+
+    // 다른 사용자들에게는 is_me: false로 전송
+    const responseToOthers = new LocalChatMessageResponseDto(roomId, message, senderInfo, false, timestamp);
+    server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.ROOM_NEW_MESSAGE, responseToOthers.data);
+
+    // 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
+    await this.chatRepository.saveChatMessage(roomId, userId, message, senderInfo, timestamp);
+
+    logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
+
+    return message;
+  }
+
+  // 방 채팅 최신 메시지 조회 (최대 30개)
+  async getRoomChatRecents(roomId: string, currentUserId?: string): Promise<ChatRecentMessageDto[]> {
+    return this.chatRepository.getChatRecents(roomId, currentUserId);
   }
 
   // 관리자 메시지 전송 헬퍼
@@ -134,38 +172,5 @@ export class ChatService {
 
     this.sendAdminMessage(server, roomId, `${targetNickname}님을 찾을 수 없습니다.`, timestamp, senderSocketId);
     logMessage(this.logger, LOG.CHAT.USER_BAN(roomId, userId, targetNickname));
-  }
-
-  // 방 채팅 메시지 브로드캐스트
-  async broadcastRoomChat(
-    server: Server,
-    roomId: string,
-    userId: string,
-    message: string,
-    senderInfo: { role: string; nickname: string; profile_image: string | null },
-    senderSocketId: string,
-  ): Promise<string> {
-    const timestamp = new Date().toISOString();
-
-    const { sanitized, hasCurse } = await this.curseWordService.sanitize(message);
-    if (hasCurse) {
-      message = sanitized;
-    }
-
-    // 다른 사용자들에게는 is_me: false로 전송
-    const responseToOthers = new LocalChatMessageResponseDto(roomId, message, senderInfo, false, timestamp);
-    server.to(roomId).except(senderSocketId).emit(WS_EVENTS_CHAT.ROOM_NEW_MESSAGE, responseToOthers.data);
-
-    // 방 채팅 메시지를 Redis에 저장 (최신 30개 유지)
-    await this.chatRepository.saveRoomChatMessage(roomId, userId, message, senderInfo, timestamp);
-
-    logMessage(this.logger, LOG.CHAT.ROOM_BROADCAST(roomId, userId, message));
-
-    return message;
-  }
-
-  // 방 채팅 최신 메시지 조회 (최대 30개)
-  async getRoomChatRecents(roomId: string, currentUserId?: string): Promise<GlobalChatRecentMessageDto[]> {
-    return this.chatRepository.getRoomChatRecents(roomId, currentUserId);
   }
 }

--- a/be/src/modules/chat/dto/chat-response.dto.ts
+++ b/be/src/modules/chat/dto/chat-response.dto.ts
@@ -65,8 +65,8 @@ export class LocalChatMessageResponseDto {
   }
 }
 
-// 글로벌 채팅 최근 메시지 조회 응답 DTO
-export class GlobalChatRecentMessageDto {
+// 글로벌/로컬 채팅 최근 메시지 조회 응답 DTO
+export class ChatRecentMessageDto {
   message: string;
   sender: {
     role: string;
@@ -75,42 +75,4 @@ export class GlobalChatRecentMessageDto {
     is_me: boolean;
   };
   timestamp: string;
-}
-
-export class GlobalChatRecentsResponseDto {
-  messages: GlobalChatRecentMessageDto[];
-  current_participants: number;
-
-  constructor(messages: GlobalChatRecentMessageDto[], currentParticipants: number) {
-    this.messages = messages;
-    this.current_participants = currentParticipants;
-  }
-}
-
-// 글로벌 채팅 입장 ACK 응답 DTO (chat:global:join)
-export class GlobalChatJoinAckResponseDto {
-  data: {
-    room_id: string;
-    current_participants: string;
-    recents: GlobalChatRecentMessageDto[];
-  };
-
-  constructor(roomId: string, currentParticipants: number, recents: GlobalChatRecentMessageDto[]) {
-    this.data = {
-      room_id: roomId,
-      current_participants: String(currentParticipants),
-      recents,
-    };
-  }
-}
-
-// 글로벌 채팅 참여자 수 업데이트 응답 DTO
-export class GlobalChatParticipantsUpdatedResponseDto {
-  room_id: string;
-  current_participants: number;
-
-  constructor(roomId: string, currentParticipants: number) {
-    this.room_id = roomId;
-    this.current_participants = currentParticipants;
-  }
 }

--- a/be/src/modules/curse-word/curse-word.service.ts
+++ b/be/src/modules/curse-word/curse-word.service.ts
@@ -57,7 +57,8 @@ export class CurseWordService implements OnModuleInit {
       return { text: chars.join(''), map };
     };
 
-    const normKorean = buildNormalized((ch) => /[가-힣]/.test(ch));
+    // 한글 완성형 + 자모(초성, 중성) 포함
+    const normKorean = buildNormalized((ch) => /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(ch));
     const normEnglish = buildNormalized((ch) => /[A-Za-z]/.test(ch));
 
     if (normKorean.text.length === 0 && normEnglish.text.length === 0) {
@@ -71,7 +72,8 @@ export class CurseWordService implements OnModuleInit {
       if (!word) continue;
 
       // 단어가 한글을 포함하면 한글 정규화 문자열을, 아니면 영문 정규화 문자열을 사용
-      const isKoreanWord = /[가-힣]/.test(word);
+      // 한글 완성형 + 자모(초성, 중성) 포함
+      const isKoreanWord = /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(word);
       const target = isKoreanWord ? normKorean : normEnglish;
       if (target.text.length === 0) continue;
 

--- a/be/src/modules/room/dto/room-response.dto.ts
+++ b/be/src/modules/room/dto/room-response.dto.ts
@@ -61,12 +61,3 @@ export class RoomJoinInfoResponseDto {
   is_private: boolean;
   is_member: boolean;
 }
-
-export class GlobalChatRecentMessageDto {
-  sender_id: string;
-  content: string;
-  nickname: string;
-  profile_image: string;
-  role: string;
-  create_date: string;
-}

--- a/be/src/modules/room/room.repository.ts
+++ b/be/src/modules/room/room.repository.ts
@@ -367,21 +367,6 @@ export class RoomRepository {
   }
 
   /**
-   * 글로벌 채팅 최신 메시지 조회
-   */
-  async getGlobalChatRecents(roomId: string): Promise<any[]> {
-    try {
-      const recentsKey = `room:${roomId}:recents`;
-      const messages = await this.redisClient.lRange(recentsKey, 0, -1);
-      return messages.map((msg) => JSON.parse(msg));
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`글로벌 채팅 최신 메시지 조회 실패: ${errorMessage}`);
-      return [];
-    }
-  }
-
-  /**
    * 게임 관련 필드 조회
    */
   async getGameField(roomId: string, field: string): Promise<string | null> {

--- a/be/src/modules/room/room.service.ts
+++ b/be/src/modules/room/room.service.ts
@@ -26,7 +26,6 @@ import {
   ParticipantDto,
   RoomListResponseDto,
   RoomJoinInfoResponseDto,
-  GlobalChatRecentMessageDto,
   ParticipantDetailDto,
 } from './dto/room-response.dto';
 import { Server, Socket } from 'socket.io';
@@ -678,13 +677,6 @@ export class RoomService implements OnModuleInit {
    */
   async notifyParticipantsUpdated(server: Server, roomId: string, currentParticipants: number): Promise<void> {
     await this.roomNotificationService.notifyParticipantsUpdated(server, roomId, currentParticipants);
-  }
-
-  /**
-   * 글로벌 채팅 최신 메시지 조회
-   */
-  async getGlobalChatRecents(roomId: string): Promise<GlobalChatRecentMessageDto[]> {
-    return await this.roomRepository.getGlobalChatRecents(roomId);
   }
 
   /**

--- a/be/src/providers/database/migrations/1769608123640-UpdateCurseWords.ts
+++ b/be/src/providers/database/migrations/1769608123640-UpdateCurseWords.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateCurseWords1769608123640 implements MigrationInterface {
+  private readonly INSERT_CURSE_WORDS = ['ㅅㅂ', 'ㅗ'];
+
+  private readonly DELETE_CURSE_WORDS = ['꺼져', 'hell', 'ass', 'omg'];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 비속어 데이터 삽입
+    const values = this.INSERT_CURSE_WORDS.map((word) => `(UNHEX(REPLACE(UUID(), '-', '')), '${word}')`).join(
+      ',\n        ',
+    );
+
+    await queryRunner.query(`
+      INSERT INTO \`curse_word\` (\`id\`, \`word\`)
+      VALUES
+        ${values}
+    `);
+    // 비속어 데이터 삭제
+    const words = this.DELETE_CURSE_WORDS.map((word) => `'${word}'`).join(', ');
+
+    await queryRunner.query(`
+      DELETE FROM \`curse_word\`
+      WHERE \`word\` IN (${words})
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 비속어 데이터 삭제
+    const words = this.INSERT_CURSE_WORDS.map((word) => `'${word}'`).join(', ');
+
+    await queryRunner.query(`
+      DELETE FROM \`curse_word\`
+      WHERE \`word\` IN (${words})
+    `);
+
+    // 비속어 데이터 삽입
+    const values = this.DELETE_CURSE_WORDS.map((word) => `(UNHEX(REPLACE(UUID(), '-', '')), '${word}')`).join(
+      ',\n        ',
+    );
+
+    await queryRunner.query(`
+      INSERT INTO \`curse_word\` (\`id\`, \`word\`)
+      VALUES
+        ${values}
+    `);
+  }
+}

--- a/fe/src/app/features/chat/services/GlobalChatService.ts
+++ b/fe/src/app/features/chat/services/GlobalChatService.ts
@@ -20,6 +20,7 @@ export class GlobalChatService implements callback.ChatChannel {
   private messages: chatData.ChatReceiveData[] = [];
   private currentParticipants = 0;
   private isUnread = false;
+  private isInitialized = false;
 
   private eventHandlers: Map<string, (...args: any[]) => void> = new Map();
   private handlersRegistered = false;
@@ -61,7 +62,22 @@ export class GlobalChatService implements callback.ChatChannel {
     await this.ensureConnected();
     if (!WebSocketService.isConnected()) return;
 
+    // React StrictMode 등으로 동일 effect가 두 번 실행될 수 있으므로 비동기 처리 이후에도 다시 한 번 구독 여부 확인
+    if (this.isSubscribed) return;
+
     this.isSubscribed = true;
+
+    // 웹소켓 연결 후 초기 데이터 요청
+    try {
+      const initDto = (await WebSocketService.request(
+        wsEvents.WS_EVENTS.CHAT_GLOBAL_INIT,
+        {},
+      )) as chatDto.GlobalChatInitDto;
+
+      this.handleGlobalChatInit(initDto);
+    } catch (error) {
+      console.error('[GlobalChatService] 초기 데이터 요청 실패:', error);
+    }
   }
 
   async unsubscribe(): Promise<void> {
@@ -73,6 +89,7 @@ export class GlobalChatService implements callback.ChatChannel {
     this.connectPromise = undefined;
     this.boundSocket = undefined;
     this.isSubscribed = false;
+    this.isInitialized = false;
   }
 
   async sendMessage(message: string): Promise<void> {
@@ -127,6 +144,10 @@ export class GlobalChatService implements callback.ChatChannel {
 
   onInit(cb: callback.InitCallback): () => void {
     this.initCallbacks.add(cb);
+    // 이미 초기화가 완료되었다면 즉시 콜백 호출
+    if (this.isInitialized) {
+      cb(this.currentParticipants, this.messages);
+    }
     return () => this.initCallbacks.delete(cb);
   }
 
@@ -194,11 +215,6 @@ export class GlobalChatService implements callback.ChatChannel {
     this.eventHandlers.set(wsEvents.WS_EVENTS.CHAT_GLOBAL_PARTICIPANTS_UPDATED, onParticipants);
     WebSocketService.on(wsEvents.WS_EVENTS.CHAT_GLOBAL_PARTICIPANTS_UPDATED, onParticipants);
 
-    // chat:global:init
-    const onInit = (dto: chatDto.GlobalChatInitDto) => this.handleGlobalChatInit(dto);
-    this.eventHandlers.set(wsEvents.WS_EVENTS.CHAT_GLOBAL_INIT, onInit);
-    WebSocketService.on(wsEvents.WS_EVENTS.CHAT_GLOBAL_INIT, onInit);
-
     // error
     const onError = (error: any) => this.handleError(error);
     this.eventHandlers.set(wsEvents.WS_EVENTS.ERROR, onError);
@@ -228,13 +244,10 @@ export class GlobalChatService implements callback.ChatChannel {
 
     this.currentParticipants = data.currentParticipants ?? 0;
     this.messages = [...data.messages];
+    this.isInitialized = true;
 
     this.notifyInit(this.currentParticipants, this.messages);
-
-    if (dto.current_participants != null) {
-      this.currentParticipants = dto.current_participants;
-      this.notifyParticipants(this.currentParticipants);
-    }
+    this.notifyParticipants(this.currentParticipants);
   }
 
   private handleError(error: any): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/websockets@11.1.12)(rxjs@7.8.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.2)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.2)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))
       '@nestjs/websockets':
         specifier: ^11.1.12
         version: 11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)(@nestjs/platform-socket.io@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -129,7 +129,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12))
+        version: 10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)(@nestjs/platform-express@10.4.22)
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.25
@@ -166,6 +166,9 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.8.1
+      sonarqube-scanner:
+        specifier: ^4.3.4
+        version: 4.3.4
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -1840,6 +1843,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2002,12 +2009,23 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
   axios@1.13.4:
     resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  b4a@1.7.3:
+    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2056,6 +2074,14 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2278,6 +2304,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
@@ -2805,6 +2835,9 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2845,6 +2878,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -2970,6 +3006,10 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+    engines: {node: '>=14.14'}
 
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
@@ -3160,6 +3200,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -3954,6 +3998,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
+    engines: {node: '>= 6.13.0'}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -4211,6 +4259,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  properties-file@3.6.3:
+    resolution: {integrity: sha512-T0BLq5U7vMtfoHMAyirR386h/PkS9rva/EQIvy3yFmkYIjc485tgxN7eHgbtJx48O28A94MUYuRGF/iyC/L54A==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -4507,6 +4558,10 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
+
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
@@ -4521,6 +4576,11 @@ packages:
   socket.io@4.8.3:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
+
+  sonarqube-scanner@4.3.4:
+    resolution: {integrity: sha512-2qsTf6kMULo9TnrCAdGMJffPhaLljvydM2mI0v4XRzTtZDAIcnBWpLgiX2+PSysNb3LfbCbsf+pRUArqQpEhLg==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4583,6 +4643,9 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  streamx@2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -4718,9 +4781,13 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   tar@7.5.4:
     resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -4751,6 +4818,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -6337,7 +6407,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12))':
+  '@nestjs/testing@10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)(@nestjs/platform-express@10.4.22)':
     dependencies:
       '@nestjs/common': 11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -6345,7 +6415,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.2)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.16.2)(redis@5.10.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.12(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -7248,6 +7318,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adm-zip@0.5.16: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.12.0):
@@ -7426,6 +7498,14 @@ snapshots:
 
   axe-core@4.11.1: {}
 
+  axios@1.13.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.13.4:
     dependencies:
       follow-redirects: 1.15.11
@@ -7435,6 +7515,8 @@ snapshots:
       - debug
 
   axobject-query@4.1.0: {}
+
+  b4a@1.7.3: {}
 
   babel-jest@29.7.0(@babel/core@7.28.6):
     dependencies:
@@ -7548,6 +7630,8 @@ snapshots:
     optional: true
 
   balanced-match@1.0.2: {}
+
+  bare-events@2.8.2: {}
 
   base64-js@1.5.1: {}
 
@@ -7781,6 +7865,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@13.1.0: {}
 
   commander@14.0.2: {}
 
@@ -8475,6 +8561,12 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   execa@5.1.1:
@@ -8552,6 +8644,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -8691,6 +8785,12 @@ snapshots:
   fresh@0.5.2: {}
 
   fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -8912,6 +9012,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hpagent@1.2.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -9966,6 +10068,8 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-forge@1.3.3: {}
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
@@ -10218,6 +10322,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  properties-file@3.6.3: {}
 
   protobufjs@7.5.4:
     dependencies:
@@ -10591,6 +10697,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slugify@1.6.6: {}
+
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -10631,6 +10739,24 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  sonarqube-scanner@4.3.4:
+    dependencies:
+      adm-zip: 0.5.16
+      axios: 1.13.2
+      commander: 13.1.0
+      fs-extra: 11.3.3
+      hpagent: 1.2.0
+      node-forge: 1.3.3
+      properties-file: 3.6.3
+      proxy-from-env: 1.1.0
+      semver: 7.7.3
+      slugify: 1.6.6
+      tar-stream: 3.1.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - debug
+      - react-native-b4a
 
   source-map-js@1.2.1: {}
 
@@ -10676,6 +10802,15 @@ snapshots:
       internal-slot: 1.1.0
 
   streamsearch@1.1.0: {}
+
+  streamx@2.23.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   strict-event-emitter@0.5.1:
     optional: true
@@ -10836,6 +10971,15 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   tar@7.5.4:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -10873,6 +11017,12 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  text-decoder@1.2.3:
+    dependencies:
+      b4a: 1.7.3
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [ ] 기능 구현
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

### chat 도메인 리팩토링
**책임 분리 진행**

- chat 도메인 내 책임분리
  - **ChatGateway**: WebSocket 이벤트 처리 및 클라이언트 통신
  - **ChatService**: 비즈니스 로직 (메시지 브로드캐스트, 비속어 필터링, ban 명령어 처리)
  - **ChatRepository**: 데이터 접근 계층 (Redis 저장/조회)

- 글로벌 채팅 최근 메시지 송신 기능을 `RoomService`에서 `ChatService`로 이동
    - room과 chat 도메인 기능 분리
    - 채팅 관련 로직을 `ChatService`에 집중시켜 단일 책임 원칙(SRP) 준수
    - `RoomService`는 방 관리에만 집중하도록 책임 분리 
 
    → 도메인 별 책임 분리
    

### 글로벌/로컬 Redis 저장 형식 수정 및 코드 중복 제거

- 글로벌 / 로컬 채팅 저장 로직, DTO 통합
    - 변경 전
        - `saveGlobalChatMessage()`
        - `saveRoomChatMessage()`
    - 변경 후
        - `saveChatMessage()`: 글로벌/로컬 채팅 메시지 통합 저장
        - 글로벌 / 로컬 채팅 메시지 Redis 저장 로직, DTO 통합 (최신 30개 유지)

- 글로벌/로컬 최신 메시지 조회 로직, DTO 통합
    - 변경 전
        - `getGlobalChatMessage()`
        - `getLocalChatMessage()`
    - 변경 후
        - `getChatRecents()` : 글로벌/로컬 채팅 최신 메시지 통합 조회
    
    → 코드 중복을 제거
    
    → Redis 저장 형식 통일
```tsx
        // 변경 전 (saveGlobalChatMessage)
        {
          sender_id: string,
          message: string,
          content: string,
          sender: { role, nickname, profile_image },
          role: string,
          nickname: string,
          profile_image: string,
          timestamp: string,
          create_date: string
        }
        
        // 변경 후 (saveChatMessage)
        {
          sender_id: string,
          message: string,
          sender: {
            role: string,
            nickname: string,
            profile_image: string | null,
            is_me: boolean
          },
          timestamp: string
        }
```

**개선 효과**

1. **책임 분리**: 채팅 관련 로직이 `ChatService`에 집중되어 유지보수성 향상
2. **코드 중복 제거**: 메시지 저장/조회 로직 통합으로 중복 코드 제거
3. **일관성 향상**: 모든 채팅 메시지가 동일한 형식으로 저장되고 조회됨
4. **확장성**: 새로운 채팅 타입 추가 시 `ChatService`만 수정하면 됨
5. **타입 안정성**: 일관된 `ChatRecentMessageDto`로 타입 안정성 향상

### 비속어 필터링 수정
- 초성만 존재하거나 모음만 존재하는 비속어도 필터링 가능하도록 수정
- 비속어에도 포함되지만 일상에서도 쓰이는 단어일 경우 필터링 항목에서 제외

### 메인화면 이동 시 글로벌 채팅 초기 데이터를 받아오지 못하는 오류 해결
- 문제점
  - 대화방 -> 메인화면 이동시 (로고 클릭) 기존 메시지 데이터를 가져오지 못하는 오류가 존재
- 이유
  - chat:global:join과 웹소켓 연결 시 중복으로 최신 메시지를 받아오는 로직이 있어 그걸 웹소켓 연결 시 최신 메시지 event push 하도록 변경하도록 수정했는데 이로 인해 메인화면으로 이동하면서 컴포넌트 재마운트 시 초기 데이터를 요청하는 로직이 사라짐
- 해결
  - `chat:global:init` 라는 event로 통일하여 웹소켓 연결 시 그리고 컴포넌트 재마운트 시 프론트에서 백으로 리소스 요청하도록 함 (event push(x) ack(o))

- 자세한 사항은 하단의 노션 정리 참고

### sonar qube 검사 진행
> main.ts, dto, entity 등 구조가 반복되는 파일과 mock 데이터 관련과 시딩, 마이그레이션은 제외함
```tsx
sonar.exclusions=**/node_modules/**, **/dist/**, **/*.spec.ts, src/mocks/users.js, src/providers/database/migrations/*.ts, src/scripts/*.ts, src/common/utils/user-id.ts
```

- 오늘 작업 진행 전
  - <img width="1150" height="648" alt="image" src="https://github.com/user-attachments/assets/4b0711a3-9b5e-42e6-aa5b-02c5424481dd" />
  - <img width="1136" height="312" alt="image" src="https://github.com/user-attachments/assets/f1e99afb-c074-4837-9d26-659dcb47b58e" />


- 오늘 작업 진행 후
  - <img width="1136" height="640" alt="image" src="https://github.com/user-attachments/assets/b270d9a0-9574-4936-82d1-a4ef369327b9" />

---

## 🔗 연관 이슈 번호
> 이 PR이 해결하는(또는 관련된) 이슈 번호를 명시
> (예: `close #67`)

- close #280
- close #281
- close #285

---

## 🧩 주요 고민 및 해결 과정
> 주요 고민이나 문제 해결 과정 공유 
> (정리된 노션 문서가 있다면 링크 추가)

- [메인화면 이동 시 글로벌 채팅 초기 데이터를 받아오지 못하는 오류](https://rapid-bubble-113.notion.site/2fc207f2334180c484e9cd54f2cc1fba?source=copy_link)
- [SonarQube로 코드 품질 관리](https://rapid-bubble-113.notion.site/SonarQube-2fc207f233418024a39ef14f14ced452?source=copy_link)
