### PR TITLE
[Fix] 매크로 제재 error 토스트메시지 핸들러 등록

### DIFF
--- a/fe/src/app/features/chat/services/GlobalChatService.ts
+++ b/fe/src/app/features/chat/services/GlobalChatService.ts
@@ -8,7 +8,6 @@ import { WebSocketService } from '@/app/services/websocket.service';
 import { authStore } from '@/app/features/user/stores/auth';
 import * as callback from './type';
 import { chatPanelStore } from '@/app/features/chat/stores/chatPanel';
-import { toastStore } from '@/app/components/shared/toast/toast.store';
 
 export class GlobalChatService implements callback.ChatChannel {
   private messageCallbacks: Set<callback.MessageCallback> = new Set();
@@ -176,7 +175,6 @@ export class GlobalChatService implements callback.ChatChannel {
       this.notifyParticipants(this.currentParticipants);
     };
     const onInit = (dto: chatDto.GlobalChatInitDto) => this.handleGlobalChatInit(dto);
-    const onError = (error: any) => this.handleError(error);
 
     this.connectionHandlers.push(
       { event: wsEvents.WS_EVENTS.CONNECT, handler: onConnect },
@@ -184,7 +182,6 @@ export class GlobalChatService implements callback.ChatChannel {
       { event: wsEvents.WS_EVENTS.CHAT_GLOBAL_NEW_MESSAGE, handler: onMessage },
       { event: wsEvents.WS_EVENTS.CHAT_GLOBAL_PARTICIPANTS_UPDATED, handler: onParticipants },
       { event: wsEvents.WS_EVENTS.CHAT_GLOBAL_INIT, handler: onInit },
-      { event: wsEvents.WS_EVENTS.ERROR, handler: onError },
     );
 
     this.connectionHandlers.forEach(({ event, handler }) => {
@@ -217,20 +214,6 @@ export class GlobalChatService implements callback.ChatChannel {
 
     this.notifyInit(this.currentParticipants, this.messages);
     this.notifyParticipants(this.currentParticipants);
-  }
-
-  private handleError(error: any): void {
-    console.error('[GlobalChatService] WebSocket error:', error);
-
-    // 모든 웹소켓 에러 토스트 메시지
-    let message = '오류가 발생했습니다.'; // 기본 메시지
-    if (typeof error === 'string') {
-      message = error;
-    } else if (typeof error === 'object' && error !== null && typeof error.message === 'string') {
-      message = error.message;
-    }
-
-    toastStore.getState().showErrorToast(message);
   }
 
   private notifyMessage(message: chatData.ChatReceiveData): void {

--- a/fe/src/app/features/game/services/GameService.ts
+++ b/fe/src/app/features/game/services/GameService.ts
@@ -6,6 +6,7 @@ import { HttpService } from '@/app/services/http.service';
 import { ApiResponse } from '@/app/features/room/services/type';
 import { API_BASE } from '@/app/services/api.constants';
 import { GameConverter } from '@/app/features/game/dtos/converter';
+import { toastStore } from '@/app/components/shared/toast/toast.store';
 import * as data from '@/app/features/game/dtos/data';
 import * as dto from '@/app/features/game/dtos/dto';
 import * as type from './type';
@@ -264,6 +265,19 @@ class GameService {
       this.resultCallbacks.forEach((cb) => cb(data));
     };
 
+    const errorHandler = (error: any) => {
+      console.error('[GameService] WebSocket error received:', error);
+      console.log(
+        '[GameService] Error type:',
+        typeof error,
+        'Keys:',
+        error ? Object.keys(error) : 'null',
+      );
+      const message = error?.message || '게임 처리 중 오류가 발생했습니다.';
+      console.log('[GameService] Extracted message:', message);
+      toastStore.getState().showErrorToast(message);
+    };
+
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_JOIN, joinHandler);
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_LEAVE, leaveHandler);
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_RECRUIT, recruitHandler);
@@ -274,6 +288,7 @@ class GameService {
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_START, startHandler);
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_REALTIME, realtimeHandler);
     this.eventHandlers.set(WS_EVENTS.GAME_PLAYER_RESULT, resultHandler);
+    this.eventHandlers.set(WS_EVENTS.ERROR, errorHandler);
 
     this.eventHandlers.forEach((handler, event) => {
       WebSocketService.on(event, handler);


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 수행한 주요 작업 내용을 간단히 요약

- [ ] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 작성/수정
- [ ] 기타

**구체적인 내용**

<h3>문제</h3>
<ul>
<li><strong>백엔드:</strong> <code>ForbiddenException</code> 발생 시 Gateway에서 catch하여 <code>ERROR</code> 이벤트를 클라이언트에 전송 중</li>
<li><strong>프론트엔드:</strong> <code>GameService</code>에서 <code>ERROR</code> 이벤트를 수신하는 리스너가 없어, 사용자에게 오류 토스트 메시지가 노출되지 않음</li>
</ul>
<h3>해결</h3>
<ul>
<li><code>GameService</code> 내부에 소켓 이벤트 리스너(<code>WS_EVENTS_ERROR.ERROR</code>)를 추가</li>
<li>에러 발생 시 전역 상태 관리(<code>toastStore</code>)를 통해 사용자에게 즉각적인 경고 토스트를 노출</li>
</ul>
<h3>처리 흐름</h3>

단계 | 구성 요소 | 수행 동작
-- | -- | --
Step 1 | Backend (Service) | applyMacroSanctions에서 제재 단계별 ForbiddenException 발생
Step 2 | Backend (Gateway) | 에러 catch 후 client.emit(WS_EVENTS_ERROR.ERROR, { message }) 전송
Step 3 | Frontend (Service) | GameService의 errorHandler가 해당 이벤트를 감지
Step 4 | Frontend (UI) | showErrorToast(message) 호출을 통해 화면에 경고 메시지 출력


<!-- notionvc: fa74f089-03fc-4939-9f5d-4a0fb394acb8 -->
